### PR TITLE
Clean up pagination to avoid infinite loops

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/conductorone/baton-sdk v0.1.4
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/spf13/cobra v1.7.0
+	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 	go.uber.org/zap v1.25.0
 	google.golang.org/grpc v1.57.0
 )

--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,8 @@ github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0h
 github.com/tklauser/numcpus v0.6.0/go.mod h1:FEZLMke0lhOUG6w2JadTzp0a+Nl8PF/GFkQ5UVIcaL4=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -56,7 +56,7 @@ func (s *ServiceNow) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error
 	}, nil
 }
 
-// Validates that the user has read access to all relevant tables (more information in the readme).
+// Validates that we have credentials and an endpoint. Does not validate that the credentials have all of the correct permissions.
 func (s *ServiceNow) Validate(ctx context.Context) (annotations.Annotations, error) {
 	pagination := servicenow.PaginationVars{
 		Limit: 1,
@@ -65,31 +65,6 @@ func (s *ServiceNow) Validate(ctx context.Context) (annotations.Annotations, err
 	_, _, err := s.client.GetUsers(ctx, pagination, nil)
 	if err != nil {
 		return nil, fmt.Errorf("servicenow-connector: current user is not able to list users: %w", err)
-	}
-
-	roles, _, err := s.client.GetRoles(ctx, pagination)
-	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: current user is not able to list roles: %w", err)
-	}
-
-	groups, _, err := s.client.GetGroups(ctx, pagination, nil)
-	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: current user is not able to list groups: %w", err)
-	}
-
-	_, _, err = s.client.GetUserToGroup(ctx, "", groups[0].Id, pagination)
-	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: current user is not able to list group members: %w", err)
-	}
-
-	_, _, err = s.client.GetUserToRole(ctx, "", roles[0].Id, pagination)
-	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: current user is not able to list users to roles: %w", err)
-	}
-
-	_, _, err = s.client.GetGroupToRole(ctx, "", groups[0].Id, pagination)
-	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: current user is not able to list groups to roles: %w", err)
 	}
 
 	return nil, nil

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -58,7 +58,7 @@ func (g *groupResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagi
 		return nil, "", nil, err
 	}
 
-	groups, total, err := g.client.GetGroups(
+	groups, nextPageToken, err := g.client.GetGroups(
 		ctx,
 		servicenow.PaginationVars{
 			Limit:  ResourcesPageSize,
@@ -70,7 +70,7 @@ func (g *groupResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagi
 		return nil, "", nil, fmt.Errorf("servicenow-connector: failed to list groups: %w", err)
 	}
 
-	nextPage, err := handleNextPage(bag, offset+ResourcesPageSize)
+	nextPage, err := bag.NextToken(nextPageToken)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -85,10 +85,6 @@ func (g *groupResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagi
 		}
 
 		rv = append(rv, rr)
-	}
-
-	if (offset + len(groups)) == total {
-		return rv, "", nil, nil
 	}
 
 	return rv, nextPage, nil, nil
@@ -118,7 +114,7 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, p
 		return nil, "", nil, err
 	}
 
-	groupMembers, total, err := g.client.GetUserToGroup(
+	groupMembers, nextPageToken, err := g.client.GetUserToGroup(
 		ctx,
 		"", // all users
 		resource.Id.Resource,
@@ -131,11 +127,7 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, p
 		return nil, "", nil, fmt.Errorf("servicenow-connector: failed to list groupMembers: %w", err)
 	}
 
-	if len(groupMembers) == 0 {
-		return nil, "", nil, nil
-	}
-
-	nextPage, err := handleNextPage(bag, offset+ResourcesPageSize)
+	nextPage, err := bag.NextToken(nextPageToken)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -169,10 +161,6 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, p
 				ur.Id,
 			),
 		)
-	}
-
-	if (offset + len(groupMembers)) == total {
-		return rv, "", nil, nil
 	}
 
 	return rv, nextPage, nil, nil

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -1,7 +1,6 @@
 package connector
 
 import (
-	"fmt"
 	"strconv"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -16,16 +15,6 @@ func annotationsForUserResourceType() annotations.Annotations {
 	annos := annotations.Annotations{}
 	annos.Update(&v2.SkipEntitlementsAndGrants{})
 	return annos
-}
-
-func handleNextPage(bag *pagination.Bag, page int) (string, error) {
-	nextPage := fmt.Sprintf("%d", page)
-	pageToken, err := bag.NextToken(nextPage)
-	if err != nil {
-		return "", err
-	}
-
-	return pageToken, nil
 }
 
 func parsePageToken(i string, resourceID *v2.ResourceId) (*pagination.Bag, int, error) {
@@ -50,24 +39,6 @@ func parsePageToken(i string, resourceID *v2.ResourceId) (*pagination.Bag, int, 
 	return b, page, nil
 }
 
-func handleRoleGrantsPagination(
-	grants []*v2.Grant,
-	bag *pagination.Bag,
-) ([]*v2.Grant, string, annotations.Annotations, error) {
-	bag.Pop()
-
-	if bag.Current() == nil {
-		return grants, "", nil, nil
-	}
-
-	nextPage, err := bag.Marshal()
-	if err != nil {
-		return nil, "", nil, err
-	}
-
-	return grants, nextPage, nil, nil
-}
-
 // convertPageToken converts a string token into an int.
 func convertPageToken(token string) (int, error) {
 	if token == "" {
@@ -75,26 +46,6 @@ func convertPageToken(token string) (int, error) {
 	}
 
 	return strconv.Atoi(token)
-}
-
-func mapUsers(resources []servicenow.UserToRole) []string {
-	users := make([]string, len(resources))
-
-	for i, r := range resources {
-		users[i] = r.User
-	}
-
-	return users
-}
-
-func mapGroups(resources []servicenow.GroupToRole) []string {
-	groups := make([]string, len(resources))
-
-	for i, r := range resources {
-		groups[i] = r.Group
-	}
-
-	return groups
 }
 
 func mapGroupMembers(resources []servicenow.GroupMember) []string {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -56,7 +56,7 @@ func (u *userResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagin
 		return nil, "", nil, err
 	}
 
-	users, total, err := u.client.GetUsers(
+	users, nextPageToken, err := u.client.GetUsers(
 		ctx,
 		servicenow.PaginationVars{
 			Limit:  ResourcesPageSize,
@@ -68,7 +68,7 @@ func (u *userResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagin
 		return nil, "", nil, fmt.Errorf("servicenow-connector: failed to list users: %w", err)
 	}
 
-	nextPage, err := handleNextPage(bag, offset+ResourcesPageSize)
+	nextPage, err := bag.NextToken(nextPageToken)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -83,10 +83,6 @@ func (u *userResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagin
 		}
 
 		rv = append(rv, ur)
-	}
-
-	if (offset + len(users)) == total {
-		return rv, "", nil, nil
 	}
 
 	return rv, nextPage, nil, nil

--- a/vendor/github.com/tomnomnom/linkheader/.gitignore
+++ b/vendor/github.com/tomnomnom/linkheader/.gitignore
@@ -1,0 +1,2 @@
+cpu.out
+linkheader.test

--- a/vendor/github.com/tomnomnom/linkheader/.travis.yml
+++ b/vendor/github.com/tomnomnom/linkheader/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+
+go:
+  - 1.6
+  - 1.7
+  - tip

--- a/vendor/github.com/tomnomnom/linkheader/CONTRIBUTING.mkd
+++ b/vendor/github.com/tomnomnom/linkheader/CONTRIBUTING.mkd
@@ -1,0 +1,10 @@
+# Contributing
+
+* Raise an issue if appropriate
+* Fork the repo
+* Bootstrap the dev dependencies (run `./script/bootstrap`)
+* Make your changes
+* Use [gofmt](https://golang.org/cmd/gofmt/)
+* Make sure the tests pass (run `./script/test`)
+* Make sure the linters pass (run `./script/lint`)
+* Issue a pull request

--- a/vendor/github.com/tomnomnom/linkheader/LICENSE
+++ b/vendor/github.com/tomnomnom/linkheader/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Tom Hudson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/tomnomnom/linkheader/README.mkd
+++ b/vendor/github.com/tomnomnom/linkheader/README.mkd
@@ -1,0 +1,35 @@
+# Golang Link Header Parser
+
+Library for parsing HTTP Link headers. Requires Go 1.6 or higher.
+
+Docs can be found on [the GoDoc page](https://godoc.org/github.com/tomnomnom/linkheader).
+
+[![Build Status](https://travis-ci.org/tomnomnom/linkheader.svg)](https://travis-ci.org/tomnomnom/linkheader)
+
+## Basic Example
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/tomnomnom/linkheader"
+)
+
+func main() {
+	header := "<https://api.github.com/user/58276/repos?page=2>; rel=\"next\"," +
+		"<https://api.github.com/user/58276/repos?page=2>; rel=\"last\""
+	links := linkheader.Parse(header)
+
+	for _, link := range links {
+		fmt.Printf("URL: %s; Rel: %s\n", link.URL, link.Rel)
+	}
+}
+
+// Output:
+// URL: https://api.github.com/user/58276/repos?page=2; Rel: next
+// URL: https://api.github.com/user/58276/repos?page=2; Rel: last
+```
+
+

--- a/vendor/github.com/tomnomnom/linkheader/main.go
+++ b/vendor/github.com/tomnomnom/linkheader/main.go
@@ -1,0 +1,151 @@
+// Package linkheader provides functions for parsing HTTP Link headers
+package linkheader
+
+import (
+	"fmt"
+	"strings"
+)
+
+// A Link is a single URL and related parameters
+type Link struct {
+	URL    string
+	Rel    string
+	Params map[string]string
+}
+
+// HasParam returns if a Link has a particular parameter or not
+func (l Link) HasParam(key string) bool {
+	for p := range l.Params {
+		if p == key {
+			return true
+		}
+	}
+	return false
+}
+
+// Param returns the value of a parameter if it exists
+func (l Link) Param(key string) string {
+	for k, v := range l.Params {
+		if key == k {
+			return v
+		}
+	}
+	return ""
+}
+
+// String returns the string representation of a link
+func (l Link) String() string {
+
+	p := make([]string, 0, len(l.Params))
+	for k, v := range l.Params {
+		p = append(p, fmt.Sprintf("%s=\"%s\"", k, v))
+	}
+	if l.Rel != "" {
+		p = append(p, fmt.Sprintf("%s=\"%s\"", "rel", l.Rel))
+	}
+	return fmt.Sprintf("<%s>; %s", l.URL, strings.Join(p, "; "))
+}
+
+// Links is a slice of Link structs
+type Links []Link
+
+// FilterByRel filters a group of Links by the provided Rel attribute
+func (l Links) FilterByRel(r string) Links {
+	links := make(Links, 0)
+	for _, link := range l {
+		if link.Rel == r {
+			links = append(links, link)
+		}
+	}
+	return links
+}
+
+// String returns the string representation of multiple Links
+// for use in HTTP responses etc
+func (l Links) String() string {
+	if l == nil {
+		return fmt.Sprint(nil)
+	}
+
+	var strs []string
+	for _, link := range l {
+		strs = append(strs, link.String())
+	}
+	return strings.Join(strs, ", ")
+}
+
+// Parse parses a raw Link header in the form:
+//   <url>; rel="foo", <url>; rel="bar"; wat="dis"
+// returning a slice of Link structs
+func Parse(raw string) Links {
+	var links Links
+
+	// One chunk: <url>; rel="foo"
+	for _, chunk := range strings.Split(raw, ",") {
+
+		link := Link{URL: "", Rel: "", Params: make(map[string]string)}
+
+		// Figure out what each piece of the chunk is
+		for _, piece := range strings.Split(chunk, ";") {
+
+			piece = strings.Trim(piece, " ")
+			if piece == "" {
+				continue
+			}
+
+			// URL
+			if piece[0] == '<' && piece[len(piece)-1] == '>' {
+				link.URL = strings.Trim(piece, "<>")
+				continue
+			}
+
+			// Params
+			key, val := parseParam(piece)
+			if key == "" {
+				continue
+			}
+
+			// Special case for rel
+			if strings.ToLower(key) == "rel" {
+				link.Rel = val
+			} else {
+				link.Params[key] = val
+			}
+		}
+
+		if link.URL != "" {
+			links = append(links, link)
+		}
+	}
+
+	return links
+}
+
+// ParseMultiple is like Parse, but accepts a slice of headers
+// rather than just one header string
+func ParseMultiple(headers []string) Links {
+	links := make(Links, 0)
+	for _, header := range headers {
+		links = append(links, Parse(header)...)
+	}
+	return links
+}
+
+// parseParam takes a raw param in the form key="val" and
+// returns the key and value as seperate strings
+func parseParam(raw string) (key, val string) {
+
+	parts := strings.SplitN(raw, "=", 2)
+	if len(parts) == 1 {
+		return parts[0], ""
+	}
+	if len(parts) != 2 {
+		return "", ""
+	}
+
+	key = parts[0]
+	val = strings.Trim(parts[1], "\"")
+
+	return key, val
+
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -317,6 +317,9 @@ github.com/tklauser/go-sysconf
 # github.com/tklauser/numcpus v0.6.1
 ## explicit; go 1.13
 github.com/tklauser/numcpus
+# github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
+## explicit
+github.com/tomnomnom/linkheader
 # github.com/yusufpapurcu/wmi v1.2.3
 ## explicit; go 1.16
 github.com/yusufpapurcu/wmi


### PR DESCRIPTION
With the previous implementation, if a result returned zero rows, it'd result in an infinite loop.

By default, Servicenow's pagination leaves a lot to be desired. After more reading, I realized that they also include `Link` headers that we can parse for pagination details. This PR uses that to determine the next offset, and allows us to only paginate when we know there are more pages instead of trying to infer it from the number of results we are returned.

Also noticed that we could be more efficient with how we calculate grants for roles. By avoiding fetching the full principals for role grants, it cut the sync time by more than 50% for me.