### PR TITLE
Fix linter issues and deprecated linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,7 +57,6 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - deadcode # Finds unused code
     - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
     - gosimple # Linter for Go source code that specializes in simplifying a code
     - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
@@ -65,7 +64,6 @@ linters:
     - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
     - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
     - unused # Checks Go code for unused constants, variables, functions and types
-    - varcheck # Finds unused global variables and constants
     - asasalint # Check for pass []any as any in variadic func(...any)
     - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
     - bidichk # Checks for dangerous unicode character sequences

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -132,13 +132,13 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, p
 		return nil, "", nil, err
 	}
 
-	memberIds := mapGroupMembers(groupMembers)
+	memberIDs := mapGroupMembers(groupMembers)
 	targetMembers, _, err := g.client.GetUsers(
 		ctx,
 		servicenow.PaginationVars{
-			Limit: len(memberIds),
+			Limit: len(memberIDs),
 		},
-		memberIds,
+		memberIDs,
 	)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("servicenow-connector: failed to list members under group %s: %w", resource.Id.Resource, err)

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -70,7 +70,7 @@ func NewClient(httpClient *http.Client, auth string, deployment string) *Client 
 }
 
 // Table `sys_user` (Users).
-func (c *Client) GetUsers(ctx context.Context, paginationVars PaginationVars, userIds []string) ([]User, string, error) {
+func (c *Client) GetUsers(ctx context.Context, paginationVars PaginationVars, userIDs []string) ([]User, string, error) {
 	var usersResponse UsersResponse
 
 	nextPage, err := c.get(
@@ -79,7 +79,7 @@ func (c *Client) GetUsers(ctx context.Context, paginationVars PaginationVars, us
 		&usersResponse,
 		[]QueryParam{
 			&paginationVars,
-			prepareUserFilters(userIds),
+			prepareUserFilters(userIDs),
 		}...,
 	)
 
@@ -110,7 +110,7 @@ func (c *Client) GetUser(ctx context.Context, userId string) (*User, error) {
 }
 
 // Table `sys_user_group` (Groups).
-func (c *Client) GetGroups(ctx context.Context, paginationVars PaginationVars, groupIds []string) ([]Group, string, error) {
+func (c *Client) GetGroups(ctx context.Context, paginationVars PaginationVars, groupIDs []string) ([]Group, string, error) {
 	var groupsResponse GroupsResponse
 
 	nextPageToken, err := c.get(
@@ -119,7 +119,7 @@ func (c *Client) GetGroups(ctx context.Context, paginationVars PaginationVars, g
 		&groupsResponse,
 		[]QueryParam{
 			&paginationVars,
-			prepareGroupFilters(groupIds),
+			prepareGroupFilters(groupIDs),
 		}...,
 	)
 

--- a/pkg/servicenow/request.go
+++ b/pkg/servicenow/request.go
@@ -12,14 +12,14 @@ var (
 	GroupFields = []string{"sys_id", "description", "name"}
 )
 
-func queryMultipleIds(ids []string) string {
-	var preparedIds []string
+func queryMultipleIDs(ids []string) string {
+	var preparedIDs []string
 
 	for _, id := range ids {
-		preparedIds = append(preparedIds, fmt.Sprintf("sys_id=%s", id))
+		preparedIDs = append(preparedIDs, fmt.Sprintf("sys_id=%s", id))
 	}
 
-	return strings.Join(preparedIds, "^OR")
+	return strings.Join(preparedIDs, "^OR")
 }
 
 type QueryParam interface {
@@ -65,7 +65,7 @@ func prepareUserFilters(ids []string) *FilterVars {
 	var query string
 
 	if ids != nil {
-		query = queryMultipleIds(ids)
+		query = queryMultipleIDs(ids)
 	}
 
 	return &FilterVars{
@@ -85,7 +85,7 @@ func prepareGroupFilters(ids []string) *FilterVars {
 	var query string
 
 	if ids != nil {
-		query = queryMultipleIds(ids)
+		query = queryMultipleIDs(ids)
 	}
 
 	return &FilterVars{


### PR DESCRIPTION
- Fix linter issues and deprecated linter

var-naming: func queryMultipleIds should be queryMultipleIDs
var-naming: var preparedIds should be preparedIDs
var-naming: method parameter userIds should be userIDs
var-naming: method parameter groupIds should be groupIDs
var-naming: var memberIds should be memberIDs