### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-servicenow/main.go
+++ b/cmd/baton-servicenow/main.go
@@ -62,7 +62,7 @@ func getConnector(ctx context.Context, snc *config.ServiceNow) (types.ConnectorS
 		ticketSchemaFilters["sysparm_category"] = categoryId
 	}
 
-	servicenowConnector, err := connector.New(ctx, auth, snc.Deployment, ticketSchemaFilters, snc.AllowedDomains, snc.CustomUserFields)
+	servicenowConnector, err := connector.New(ctx, auth, snc.Deployment, ticketSchemaFilters, snc.AllowedDomains, snc.CustomUserFields, snc.BaseUrl)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/cmd/baton-servicenow/main.go
+++ b/cmd/baton-servicenow/main.go
@@ -62,7 +62,7 @@ func getConnector(ctx context.Context, snc *config.ServiceNow) (types.ConnectorS
 		ticketSchemaFilters["sysparm_category"] = categoryId
 	}
 
-	servicenowConnector, err := connector.New(ctx, auth, snc.Deployment, ticketSchemaFilters, snc.AllowedDomains, snc.CustomUserFields, snc.BaseUrl)
+	servicenowConnector, err := connector.New(ctx, auth, snc.Deployment, ticketSchemaFilters, snc.AllowedDomains, snc.CustomUserFields, snc.BaseUrl, snc.Insecure)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -12,6 +12,7 @@ type ServiceNow struct {
 	AllowedDomains []string `mapstructure:"allowed-domains"`
 	CustomUserFields []string `mapstructure:"custom-user-fields"`
 	Ticketing bool `mapstructure:"ticketing"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *ServiceNow) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -13,6 +13,7 @@ type ServiceNow struct {
 	CustomUserFields []string `mapstructure:"custom-user-fields"`
 	Ticketing bool `mapstructure:"ticketing"`
 	BaseUrl string `mapstructure:"base-url"`
+	Insecure bool `mapstructure:"insecure"`
 }
 
 func (c *ServiceNow) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,11 @@ var (
 		field.WithDefaultValue([]string{}),
 	)
 	externalTicketField = field.TicketingField.ExportAs(field.ExportTargetGUI)
+	baseURLField = field.StringField("base-url",
+		field.WithDescription("Override the ServiceNow API URL (for testing)"),
+		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
+	)
 )
 
 // configurationFields defines the external configuration required for the connector to run.
@@ -47,6 +52,7 @@ var configurationFields = []field.SchemaField{
 	allowedDomainsField,
 	customUserFieldsField,
 	externalTicketField,
+	baseURLField,
 }
 
 var configRelations = []field.SchemaFieldRelationship{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,12 @@ var (
 		field.WithHidden(true),
 		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
+	insecureField = field.BoolField("insecure",
+		field.WithDescription("Allow insecure TLS connections (for testing with self-signed certificates)"),
+		field.WithDefaultValue(false),
+		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
+	)
 )
 
 // configurationFields defines the external configuration required for the connector to run.
@@ -53,6 +59,7 @@ var configurationFields = []field.SchemaField{
 	customUserFieldsField,
 	externalTicketField,
 	baseURLField,
+	insecureField,
 }
 
 var configRelations = []field.SchemaFieldRelationship{

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -115,13 +115,13 @@ func (s *ServiceNow) Validate(ctx context.Context) (annotations.Annotations, err
 }
 
 // New returns the ServiceNow connector.
-func New(ctx context.Context, auth string, deployment string, ticketSchemaFilters map[string]string, allowedDomains []string, customUserFields []string) (*ServiceNow, error) {
+func New(ctx context.Context, auth string, deployment string, ticketSchemaFilters map[string]string, allowedDomains []string, customUserFields []string, baseURL string) (*ServiceNow, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, err
 	}
 
-	servicenowClient, err := servicenow.NewClient(httpClient, auth, deployment, ticketSchemaFilters, allowedDomains, customUserFields)
+	servicenowClient, err := servicenow.NewClient(httpClient, auth, deployment, ticketSchemaFilters, allowedDomains, customUserFields, baseURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -116,7 +116,10 @@ func (s *ServiceNow) Validate(ctx context.Context) (annotations.Annotations, err
 }
 
 // New returns the ServiceNow connector.
-func New(ctx context.Context, auth string, deployment string, ticketSchemaFilters map[string]string, allowedDomains []string, customUserFields []string, baseURL string, insecure bool) (*ServiceNow, error) {
+func New(
+	ctx context.Context, auth string, deployment string, ticketSchemaFilters map[string]string,
+	allowedDomains []string, customUserFields []string, baseURL string, insecure bool,
+) (*ServiceNow, error) {
 	uhttpOpts := []uhttp.Option{uhttp.WithLogger(true, ctxzap.Extract(ctx))}
 	if insecure {
 		uhttpOpts = append(uhttpOpts, uhttp.WithTLSClientConfig(&tls.Config{InsecureSkipVerify: true})) //nolint:gosec // G402: intentional for testing with self-signed certs

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -115,8 +116,12 @@ func (s *ServiceNow) Validate(ctx context.Context) (annotations.Annotations, err
 }
 
 // New returns the ServiceNow connector.
-func New(ctx context.Context, auth string, deployment string, ticketSchemaFilters map[string]string, allowedDomains []string, customUserFields []string, baseURL string) (*ServiceNow, error) {
-	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
+func New(ctx context.Context, auth string, deployment string, ticketSchemaFilters map[string]string, allowedDomains []string, customUserFields []string, baseURL string, insecure bool) (*ServiceNow, error) {
+	uhttpOpts := []uhttp.Option{uhttp.WithLogger(true, ctxzap.Extract(ctx))}
+	if insecure {
+		uhttpOpts = append(uhttpOpts, uhttp.WithTLSClientConfig(&tls.Config{InsecureSkipVerify: true})) //nolint:gosec // G402: intentional for testing with self-signed certs
+	}
+	httpClient, err := uhttp.NewClient(ctx, uhttpOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -124,10 +124,16 @@ type Client struct {
 // https://www.servicenow.com/docs/bundle/yokohama-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html .
 // https://developer.servicenow.com/dev.do#!/reference/api/yokohama/rest/c_TableAPI?navFilter=table .
 
-func NewClient(httpClient *http.Client, auth string, deployment string, ticketSchemaFilters map[string]string, allowedDomains []string, customUserFields []string) (*Client, error) {
-	baseURL, err := GenerateURL(InstanceURLTemplate, map[string]string{"Deployment": deployment})
-	if err != nil {
-		return nil, err
+func NewClient(httpClient *http.Client, auth string, deployment string, ticketSchemaFilters map[string]string, allowedDomains []string, customUserFields []string, baseURLOverride string) (*Client, error) {
+	var baseURL string
+	if baseURLOverride != "" {
+		baseURL = baseURLOverride
+	} else {
+		var err error
+		baseURL, err = GenerateURL(InstanceURLTemplate, map[string]string{"Deployment": deployment})
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &Client{
 		httpClient:          httpClient,

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -124,7 +124,15 @@ type Client struct {
 // https://www.servicenow.com/docs/bundle/yokohama-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html .
 // https://developer.servicenow.com/dev.do#!/reference/api/yokohama/rest/c_TableAPI?navFilter=table .
 
-func NewClient(httpClient *http.Client, auth string, deployment string, ticketSchemaFilters map[string]string, allowedDomains []string, customUserFields []string, baseURLOverride string) (*Client, error) {
+func NewClient(
+	httpClient *http.Client,
+	auth string,
+	deployment string,
+	ticketSchemaFilters map[string]string,
+	allowedDomains []string,
+	customUserFields []string,
+	baseURLOverride string,
+) (*Client, error) {
 	var baseURL string
 	if baseURLOverride != "" {
 		baseURL = baseURLOverride

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -114,6 +114,7 @@ type Client struct {
 	auth                string
 	deployment          string
 	baseURL             string
+	baseURLOverride     bool
 	TicketSchemaFilters map[string]string
 	AllowedDomains      []string
 	CustomUserFields    []string
@@ -148,6 +149,7 @@ func NewClient(
 		auth:                auth,
 		deployment:          deployment,
 		baseURL:             baseURL,
+		baseURLOverride:     baseURLOverride != "",
 		TicketSchemaFilters: ticketSchemaFilters,
 		AllowedDomains:      allowedDomains,
 		CustomUserFields:    customUserFields,
@@ -162,11 +164,9 @@ func (c *Client) GetBaseURL() string {
 // When a base URL override is set, it replaces the default
 // https://DEPLOYMENT.service-now.com/api prefix with the override.
 func (c *Client) apiURL(pattern string, args ...any) string {
-	// Always insert deployment (and optional ID) into the pattern
 	expanded := fmt.Sprintf(pattern, args...)
-	// If we have an override, replace the default base with it
-	defaultBase := fmt.Sprintf("https://%s.service-now.com/api", c.deployment)
-	if c.baseURL != "" && c.baseURL != defaultBase {
+	if c.baseURLOverride {
+		defaultBase := fmt.Sprintf("https://%s.service-now.com/api", c.deployment)
 		return strings.Replace(expanded, defaultBase, c.baseURL, 1)
 	}
 	return expanded

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -492,7 +492,7 @@ func (c *Client) doRequest(ctx context.Context, urlAddress string, method string
 
 	req.URL.RawQuery = req.URL.Query().Encode()
 
-	rawResponse, err := c.httpClient.Do(req) //nolint:gosec // G704 false positive: URL is built from hardcoded API path templates and trusted deployment config
+	rawResponse, err := c.httpClient.Do(req)
 	if rawResponse != nil && rawResponse.Body != nil {
 		defer rawResponse.Body.Close()
 	}

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -158,6 +158,20 @@ func (c *Client) GetBaseURL() string {
 	return c.baseURL
 }
 
+// apiURL builds an API URL from a constant pattern like UsersBaseUrl.
+// When a base URL override is set, it replaces the default
+// https://DEPLOYMENT.service-now.com/api prefix with the override.
+func (c *Client) apiURL(pattern string, args ...any) string {
+	// Always insert deployment (and optional ID) into the pattern
+	expanded := fmt.Sprintf(pattern, args...)
+	// If we have an override, replace the default base with it
+	defaultBase := fmt.Sprintf("https://%s.service-now.com/api", c.deployment)
+	if c.baseURL != "" && c.baseURL != defaultBase {
+		return strings.Replace(expanded, defaultBase, c.baseURL, 1)
+	}
+	return expanded
+}
+
 // Table `sys_user` (Users).
 func (c *Client) GetUsers(ctx context.Context, paginationVars PaginationVars) ([]User, string, error) {
 	var usersResponse UsersResponse
@@ -167,7 +181,7 @@ func (c *Client) GetUsers(ctx context.Context, paginationVars PaginationVars) ([
 
 	nextPage, err := c.get(
 		ctx,
-		fmt.Sprintf(UsersBaseUrl, c.deployment),
+		c.apiURL(UsersBaseUrl, c.deployment),
 		&usersResponse,
 		reqOpts...,
 	)
@@ -184,7 +198,7 @@ func (c *Client) GetUser(ctx context.Context, userId string) (*User, error) {
 
 	_, err := c.get(
 		ctx,
-		fmt.Sprintf(UserBaseUrl, c.deployment, userId),
+		c.apiURL(UserBaseUrl, c.deployment, userId),
 		&userResponse,
 		WithFields(UserFields...),
 	)
@@ -204,7 +218,7 @@ func (c *Client) GetGroups(ctx context.Context, paginationVars PaginationVars, g
 	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
 	nextPageToken, err := c.get(
 		ctx,
-		fmt.Sprintf(GroupsBaseUrl, c.deployment),
+		c.apiURL(GroupsBaseUrl, c.deployment),
 		&groupsResponse,
 		reqOpts...,
 	)
@@ -221,7 +235,7 @@ func (c *Client) GetGroup(ctx context.Context, groupId string) (*Group, error) {
 
 	_, err := c.get(
 		ctx,
-		fmt.Sprintf(GroupBaseUrl, c.deployment, groupId),
+		c.apiURL(GroupBaseUrl, c.deployment, groupId),
 		&groupResponse,
 		WithFields(GroupFields...),
 	)
@@ -242,7 +256,7 @@ func (c *Client) GetUserToGroup(ctx context.Context, userId string, groupId stri
 
 	nextPageToken, err := c.get(
 		ctx,
-		fmt.Sprintf(GroupMembersBaseUrl, c.deployment),
+		c.apiURL(GroupMembersBaseUrl, c.deployment),
 		&groupMembersResponse,
 		reqOpts...,
 	)
@@ -257,7 +271,7 @@ func (c *Client) GetUserToGroup(ctx context.Context, userId string, groupId stri
 func (c *Client) AddUserToGroup(ctx context.Context, record GroupMemberPayload) error {
 	return c.post(
 		ctx,
-		fmt.Sprintf(GroupMembersBaseUrl, c.deployment),
+		c.apiURL(GroupMembersBaseUrl, c.deployment),
 		nil,
 		&record,
 		WithIncludeResponseBody(),
@@ -267,7 +281,7 @@ func (c *Client) AddUserToGroup(ctx context.Context, record GroupMemberPayload) 
 func (c *Client) RemoveUserFromGroup(ctx context.Context, id string) error {
 	return c.delete(
 		ctx,
-		fmt.Sprintf(GroupMemberDetailBaseUrl, c.deployment, id),
+		c.apiURL(GroupMemberDetailBaseUrl, c.deployment, id),
 		nil,
 	)
 }
@@ -282,7 +296,7 @@ func (c *Client) GetRoles(ctx context.Context, paginationVars PaginationVars) ([
 
 	nextPageToken, err := c.get(
 		ctx,
-		fmt.Sprintf(RolesBaseUrl, c.deployment),
+		c.apiURL(RolesBaseUrl, c.deployment),
 		&rolesResponse,
 		reqOpts...,
 	)
@@ -303,7 +317,7 @@ func (c *Client) GetUserToRole(ctx context.Context, userId string, roleId string
 
 	nextPageToken, err := c.get(
 		ctx,
-		fmt.Sprintf(UserRolesBaseUrl, c.deployment),
+		c.apiURL(UserRolesBaseUrl, c.deployment),
 		&userToRoleResponse,
 		reqOpts...,
 	)
@@ -318,7 +332,7 @@ func (c *Client) GetUserToRole(ctx context.Context, userId string, roleId string
 func (c *Client) GrantRoleToUser(ctx context.Context, record UserToRolePayload) error {
 	return c.post(
 		ctx,
-		fmt.Sprintf(UserRolesBaseUrl, c.deployment),
+		c.apiURL(UserRolesBaseUrl, c.deployment),
 		nil,
 		&record,
 		WithIncludeResponseBody(),
@@ -328,7 +342,7 @@ func (c *Client) GrantRoleToUser(ctx context.Context, record UserToRolePayload) 
 func (c *Client) RevokeRoleFromUser(ctx context.Context, id string) error {
 	return c.delete(
 		ctx,
-		fmt.Sprintf(UserRoleDetailBaseUrl, c.deployment, id),
+		c.apiURL(UserRoleDetailBaseUrl, c.deployment, id),
 		nil,
 	)
 }
@@ -341,7 +355,7 @@ func (c *Client) GetGroupToRole(ctx context.Context, groupId string, roleId stri
 	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
 	nextPageToken, err := c.get(
 		ctx,
-		fmt.Sprintf(GroupRolesBaseUrl, c.deployment),
+		c.apiURL(GroupRolesBaseUrl, c.deployment),
 		&groupToRoleResponse,
 		reqOpts...,
 	)
@@ -356,7 +370,7 @@ func (c *Client) GetGroupToRole(ctx context.Context, groupId string, roleId stri
 func (c *Client) GrantRoleToGroup(ctx context.Context, record GroupToRolePayload) error {
 	return c.post(
 		ctx,
-		fmt.Sprintf(GroupRolesBaseUrl, c.deployment),
+		c.apiURL(GroupRolesBaseUrl, c.deployment),
 		nil,
 		&record,
 		WithIncludeResponseBody(),
@@ -366,7 +380,7 @@ func (c *Client) GrantRoleToGroup(ctx context.Context, record GroupToRolePayload
 func (c *Client) RevokeRoleFromGroup(ctx context.Context, id string) error {
 	return c.delete(
 		ctx,
-		fmt.Sprintf(GroupRoleDetailBaseUrl, c.deployment, id),
+		c.apiURL(GroupRoleDetailBaseUrl, c.deployment, id),
 		nil,
 	)
 }
@@ -556,7 +570,7 @@ func (c *Client) CreateUserAccount(ctx context.Context, user any) (*User, error)
 
 	err := c.post(
 		ctx,
-		fmt.Sprintf(UsersBaseUrl, c.deployment),
+		c.apiURL(UsersBaseUrl, c.deployment),
 		&response,
 		user,
 		WithIncludeResponseBody(),
@@ -577,7 +591,7 @@ func (c *Client) UpdateUserActiveStatus(ctx context.Context, userId string, acti
 	var response UserResponse
 	err := c.patch(
 		ctx,
-		fmt.Sprintf(UserBaseUrl, c.deployment, userId),
+		c.apiURL(UserBaseUrl, c.deployment, userId),
 		&response,
 		payload,
 		WithIncludeResponseBody(),
@@ -662,7 +676,7 @@ func (c *Client) GetVariableSetLinksForItem(ctx context.Context, itemSysID strin
 	}
 	req = append(req, paginationVarsToReqOptions(&pg)...)
 
-	next, err := c.get(ctx, fmt.Sprintf(VariableSetM2MBaseUrl, c.deployment), &resp, req...)
+	next, err := c.get(ctx, c.apiURL(VariableSetM2MBaseUrl, c.deployment), &resp, req...)
 	if err != nil {
 		return nil, "", err
 	}
@@ -681,7 +695,7 @@ func (c *Client) GetVariablesBySetIDs(ctx context.Context, setIDs []string, pg P
 	}
 	req = append(req, paginationVarsToReqOptions(&pg)...)
 
-	next, err := c.get(ctx, fmt.Sprintf(ItemOptionNewBaseUrl, c.deployment), &resp, req...)
+	next, err := c.get(ctx, c.apiURL(ItemOptionNewBaseUrl, c.deployment), &resp, req...)
 	if err != nil {
 		return nil, "", err
 	}
@@ -700,7 +714,7 @@ func (c *Client) GetChoicesForVariables(ctx context.Context, varIDs []string, pg
 	}
 	req = append(req, paginationVarsToReqOptions(&pg)...)
 
-	next, err := c.get(ctx, fmt.Sprintf(QuestionChoiceBaseUrl, c.deployment), &resp, req...)
+	next, err := c.get(ctx, c.apiURL(QuestionChoiceBaseUrl, c.deployment), &resp, req...)
 	if err != nil {
 		return nil, "", err
 	}
@@ -717,7 +731,7 @@ func (c *Client) GetVariablesForItem(ctx context.Context, itemSysID string, pg P
 	}
 	req = append(req, paginationVarsToReqOptions(&pg)...)
 
-	next, err := c.get(ctx, fmt.Sprintf(ItemOptionNewBaseUrl, c.deployment), &resp, req...)
+	next, err := c.get(ctx, c.apiURL(ItemOptionNewBaseUrl, c.deployment), &resp, req...)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/servicenow/service_catalog_request.go
+++ b/pkg/servicenow/service_catalog_request.go
@@ -23,7 +23,7 @@ func (c *Client) GetServiceCatalogRequest(ctx context.Context, requestId string)
 	var serviceCatalogRequestResponse ServiceCatalogRequestResponse
 	_, err := c.get(
 		ctx,
-		fmt.Sprintf(ServiceCatalogRequestDetailsBaseUrl, c.deployment, requestId),
+		c.apiURL(ServiceCatalogRequestDetailsBaseUrl, c.deployment, requestId),
 		&serviceCatalogRequestResponse,
 		WithIncludeExternalRefLink(),
 	)
@@ -37,7 +37,7 @@ func (c *Client) GetServiceCatalogRequestItem(ctx context.Context, requestItemId
 	var requestItemResponse RequestItemResponse
 	_, err := c.get(
 		ctx,
-		fmt.Sprintf(ServiceCatalogRequestedItemDetailsBaseUrl, c.deployment, requestItemId),
+		c.apiURL(ServiceCatalogRequestedItemDetailsBaseUrl, c.deployment, requestItemId),
 		&requestItemResponse,
 		WithIncludeExternalRefLink(),
 	)
@@ -66,7 +66,7 @@ func (c *Client) UpdateServiceCatalogRequestItem(ctx context.Context, requestIte
 	var requestItemResponse RequestItemResponse
 	err := c.patch(
 		ctx,
-		fmt.Sprintf(ServiceCatalogRequestedItemDetailsBaseUrl, c.deployment, requestItemId),
+		c.apiURL(ServiceCatalogRequestedItemDetailsBaseUrl, c.deployment, requestItemId),
 		&requestItemResponse,
 		&payload,
 		WithIncludeResponseBody(),
@@ -82,7 +82,7 @@ func (c *Client) GetServiceCatalogRequestItems(ctx context.Context, reqOptions .
 	var requestItemsResponse RequestItemsResponse
 	nextPageToken, err := c.get(
 		ctx,
-		fmt.Sprintf(ServiceCatalogRequestedItemBaseUrl, c.deployment),
+		c.apiURL(ServiceCatalogRequestedItemBaseUrl, c.deployment),
 		&requestItemsResponse,
 		reqOptions...,
 	)
@@ -103,7 +103,7 @@ func (c *Client) GetCatalogItems(ctx context.Context, paginationVars *Pagination
 	}
 	nextPageToken, err := c.get(
 		ctx,
-		fmt.Sprintf(ServiceCatalogItemBaseUrl, c.deployment),
+		c.apiURL(ServiceCatalogItemBaseUrl, c.deployment),
 		&catalogItemsResponse,
 		reqOpts...,
 	)
@@ -117,7 +117,7 @@ func (c *Client) GetCatalogItem(ctx context.Context, catalogItemId string) (*Cat
 	var catalogItemResponse CatalogItemResponse
 	_, err := c.get(
 		ctx,
-		fmt.Sprintf(ServiceCatalogItemGetUrl, c.deployment, catalogItemId),
+		c.apiURL(ServiceCatalogItemGetUrl, c.deployment, catalogItemId),
 		&catalogItemResponse,
 	)
 	if err != nil {
@@ -130,7 +130,7 @@ func (c *Client) GetCatalogItemVariables(ctx context.Context, catalogItemId stri
 	var catalogItemVariablesResponse CatalogItemVariablesResponse
 	_, err := c.get(
 		ctx,
-		fmt.Sprintf(ServiceCatalogItemVariablesUrl, c.deployment, catalogItemId),
+		c.apiURL(ServiceCatalogItemVariablesUrl, c.deployment, catalogItemId),
 		&catalogItemVariablesResponse,
 	)
 	if err != nil {
@@ -158,7 +158,7 @@ func (c *Client) OrderItemNow(ctx context.Context, catalogItemId string, payload
 	var orderCatalogItemResponse OrderCatalogItemResponse
 	err := c.post(
 		ctx,
-		fmt.Sprintf(ServiceCatalogOrderItemUrl, c.deployment, catalogItemId),
+		c.apiURL(ServiceCatalogOrderItemUrl, c.deployment, catalogItemId),
 		&orderCatalogItemResponse,
 		&payload,
 		WithIncludeResponseBody(),
@@ -191,7 +191,7 @@ func (c *Client) addLabelToRequestedItem(ctx context.Context, requestedItemId st
 	var labelEntryResponse IDResponse
 	err := c.post(
 		ctx,
-		fmt.Sprintf(LabelEntryBaseUrl, c.deployment),
+		c.apiURL(LabelEntryBaseUrl, c.deployment),
 		&labelEntryResponse,
 		&LabelEntryPayload{
 			Table:    "sc_req_item",
@@ -223,7 +223,7 @@ func (c *Client) GetLabel(ctx context.Context, label string) (*Label, error) {
 	var labelsResponse LabelsResponse
 	_, err := c.get(
 		ctx,
-		fmt.Sprintf(LabelBaseUrl, c.deployment),
+		c.apiURL(LabelBaseUrl, c.deployment),
 		&labelsResponse,
 		WithQuery(fmt.Sprintf("name=%s", label)),
 	)
@@ -240,7 +240,7 @@ func (c *Client) createLabel(ctx context.Context, label string) (*Label, error) 
 	var labelResponse LabelResponse
 	err := c.post(
 		ctx,
-		fmt.Sprintf(LabelBaseUrl, c.deployment),
+		c.apiURL(LabelBaseUrl, c.deployment),
 		&labelResponse,
 		&Label{
 			ViewableBy: "everyone",
@@ -258,7 +258,7 @@ func (c *Client) GetLabelsForRequestedItem(ctx context.Context, requestedItemId 
 	var labelResponse LabelEntriesLabelNameResponse
 	_, err := c.get(
 		ctx,
-		fmt.Sprintf(LabelEntryBaseUrl, c.deployment),
+		c.apiURL(LabelEntryBaseUrl, c.deployment),
 		&labelResponse,
 		WithQuery(fmt.Sprintf("table=sc_req_item^table_key=%s", requestedItemId)),
 		WithFields("label.name"),
@@ -277,7 +277,7 @@ func (c *Client) GetServiceCatalogRequestedItemStates(ctx context.Context) ([]Re
 	var catalogsResponse RequestedItemStateResponse
 	_, err := c.get(
 		ctx,
-		fmt.Sprintf(ChoiceBaseUrl, c.deployment),
+		c.apiURL(ChoiceBaseUrl, c.deployment),
 		&catalogsResponse,
 		WithQuery("name=task^element=state^language=en^inactive=false"),
 		WithFields("label,value"),
@@ -293,7 +293,7 @@ func (c *Client) GetCatalogs(ctx context.Context, paginationVars PaginationVars)
 	var catalogsResponse CatalogsResponse
 	nextPageToken, err := c.get(
 		ctx,
-		fmt.Sprintf(ServiceCatalogListCatalogsUrl, c.deployment),
+		c.apiURL(ServiceCatalogListCatalogsUrl, c.deployment),
 		&catalogsResponse,
 		WithPageLimit(paginationVars.Limit),
 		WithOffset(paginationVars.Offset),


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-servicenow/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go,pkg/servicenow/client.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-servicenow --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to override the ServiceNow API base URL for custom instances and testing.
  * The base-URL override is honored end-to-end during connector and client initialization so all ServiceNow API calls use the override when provided.
  * The override can be set via configuration or CLI to target alternative ServiceNow deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->