### PR TITLE
[CXP-309] Fix ListTicketSchemas Lambda timeout for large ServiceNow instances

### DIFF
--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -8,7 +8,7 @@ import (
 )
 
 var ResourcesPageSize = 50
-var TicketSchemasPageSize = 10
+var TicketSchemasPageSize = 25
 
 func annotationsForUserResourceType() annotations.Annotations {
 	annos := annotations.Annotations{}

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -8,6 +8,7 @@ import (
 )
 
 var ResourcesPageSize = 50
+var TicketSchemasPageSize = 10
 
 func annotationsForUserResourceType() annotations.Annotations {
 	annos := annotations.Annotations{}

--- a/pkg/connector/ticket.go
+++ b/pkg/connector/ticket.go
@@ -21,6 +21,8 @@ import (
 )
 
 func (s *ServiceNow) ListTicketSchemas(ctx context.Context, pt *pagination.Token) ([]*v2.TicketSchema, string, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+
 	offset, err := convertPageToken(pt.Token)
 	if err != nil {
 		return nil, "", nil, err
@@ -38,6 +40,13 @@ func (s *ServiceNow) ListTicketSchemas(ctx context.Context, pt *pagination.Token
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("servicenow-connector: failed to get catalog items: %w", err)
 	}
+
+	l.Debug("listing ticket schemas",
+		zap.Int("catalog_items", len(catalogItems)),
+		zap.Int("page_size", pageSize),
+		zap.Int("offset", offset),
+		zap.String("next_page_token", nextPageToken),
+	)
 
 	requestedItemStates, err := s.client.GetServiceCatalogRequestedItemStates(ctx)
 	if err != nil {

--- a/pkg/connector/ticket.go
+++ b/pkg/connector/ticket.go
@@ -27,8 +27,11 @@ func (s *ServiceNow) ListTicketSchemas(ctx context.Context, pt *pagination.Token
 	if err != nil {
 		return nil, "", nil, err
 	}
+	// Cap page size to avoid Lambda timeouts. Each catalog item requires
+	// 3-4 HTTP roundtrips for variable sets, so large pages can exceed
+	// the execution time limit.
 	pageSize := pt.Size
-	if pageSize == 0 {
+	if pageSize > TicketSchemasPageSize {
 		pageSize = TicketSchemasPageSize
 	}
 	catalogItems, nextPageToken, err := s.client.GetCatalogItems(ctx,

--- a/pkg/connector/ticket.go
+++ b/pkg/connector/ticket.go
@@ -25,9 +25,13 @@ func (s *ServiceNow) ListTicketSchemas(ctx context.Context, pt *pagination.Token
 	if err != nil {
 		return nil, "", nil, err
 	}
+	pageSize := pt.Size
+	if pageSize == 0 {
+		pageSize = TicketSchemasPageSize
+	}
 	catalogItems, nextPageToken, err := s.client.GetCatalogItems(ctx,
 		&servicenow.PaginationVars{
-			Limit:  pt.Size,
+			Limit:  pageSize,
 			Offset: offset,
 		},
 	)

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -486,7 +486,7 @@ func (c *Client) doRequest(ctx context.Context, urlAddress string, method string
 
 	req.URL.RawQuery = req.URL.Query().Encode()
 
-	rawResponse, err := c.httpClient.Do(req) //nolint:gosec // G704 false positive: URL is built from hardcoded API path templates and trusted deployment config
+	rawResponse, err := c.httpClient.Do(req)
 	if rawResponse != nil && rawResponse.Body != nil {
 		defer rawResponse.Body.Close()
 	}


### PR DESCRIPTION
## Summary

- **Cap ListTicketSchemas page size to 25** to prevent Lambda timeouts. The SDK does not set `PageSize` when calling `ListTicketSchemas`, resulting in `0` which causes no `sysparm_limit` to be sent to ServiceNow. This fetches all catalog items in a single request, and since each item requires 3-4 HTTP roundtrips for variable sets, large instances can intermittently exceed the Lambda timeout. Capping at 25 items ≈ ~100 HTTP calls per page — a safe margin within Lambda limits.
- **Add debug logging** for pagination state (catalog item count, page size, offset, next page token) to aid future debugging.
- **Remove unused nolint directive** flagged by linter.

## Context

A customer with a large ServiceNow instance intermittently sees Lambda timeouts during sync when `ListTicketSchemas` runs — specifically on the `io_set_item` table query which fetches variable sets per catalog item. With no page size limit, the connector attempts to build schemas for all catalog items in a single invocation.

**This is a transient error.** The sync process retries and eventually succeeds, but the intermittent timeouts generate unnecessary noise and delays. Reducing the page size eliminates the issue by keeping each invocation well within Lambda limits.

The SDK's `list_ticket_schemas.go` task handler already paginates through pages (up to 100 schemas), so reducing the page size is safe — each Lambda invocation processes fewer items and the SDK automatically collects all pages.

## Test plan

- [ ] Build and run `--list-ticket-schemas` against a ServiceNow instance to verify pagination works
- [ ] Verify debug logs show expected page size and catalog item counts
- [ ] Deploy to customer environment and confirm provision state mapping options appear reliably in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)