### PR TITLE
fix: use proto Set* methods for opaque API field assignments

### DIFF
--- a/pkg/connector/ticket.go
+++ b/pkg/connector/ticket.go
@@ -130,7 +130,7 @@ func (s *ServiceNow) CreateTicket(ctx context.Context, ticket *v2.Ticket, schema
 					if requestedForID == "" {
 						requestedForID = servicenow.SystemAdminUserId
 					}
-					ticketFields[id].GetStringValue().Value = requestedForID
+					ticketFields[id].GetStringValue().SetValue(requestedForID)
 				}
 			}
 

--- a/pkg/servicenow/model.go
+++ b/pkg/servicenow/model.go
@@ -384,7 +384,7 @@ func ConvertVariableToSchemaCustomField(ctx context.Context, variable *CatalogIt
 		cf = sdkTicket.BoolFieldSchema(variable.Name, variable.Label, variable.Mandatory)
 	case TypeMultiLineText, TypeSingleLineText, TypeWideSingleLineText, TypeHTML, TypeEmail, TypeURL, TypeIPAddress:
 		cf = sdkTicket.StringFieldSchema(variable.Name, variable.Label, variable.Mandatory)
-		cf.GetStringValue().DefaultValue = variable.Value
+		cf.GetStringValue().SetDefaultValue(variable.Value)
 	case TypeMultipleChoice, TypeLookupMultipleChoice:
 		var allowedChoices []*v2.TicketCustomFieldObjectValue
 		choices := variable.Choices
@@ -410,13 +410,13 @@ func ConvertVariableToSchemaCustomField(ctx context.Context, variable *CatalogIt
 	case TypeReference:
 		// This should be a sys_id
 		cf = sdkTicket.StringFieldSchema(variable.Name, variable.Label, variable.Mandatory)
-		cf.GetStringValue().DefaultValue = variable.Value
+		cf.GetStringValue().SetDefaultValue(variable.Value)
 		typAnno.RefQualifier = variable.RefQualifier
 		typAnno.Reference = variable.Reference
 	case TypeRequestedFor:
 		// This should be sys_id of user
 		cf = sdkTicket.StringFieldSchema(variable.Name, variable.Label, variable.Mandatory)
-		cf.GetStringValue().DefaultValue = SystemAdminUserId
+		cf.GetStringValue().SetDefaultValue(SystemAdminUserId)
 	case TypeListCollector:
 		cf = sdkTicket.StringFieldSchema(variable.Name, variable.Label, variable.Mandatory)
 	case TypeDuration: // TODO(lauren) make duration field?


### PR DESCRIPTION
Four sites were assigning to fields reached through a proto opaque-API getter:

\`\`\`
cf.GetStringValue().DefaultValue = variable.Value   // 3 in pkg/servicenow/model.go
ticketFields[id].GetStringValue().Value = ...       // 1 in pkg/connector/ticket.go
\`\`\`

The opaque-API contract is *use \`Set\`/\`Has\`/\`Clear\`; do not field-access*, because the inner message returned by \`Get*\` is conceptually a read view; mutation should go through the typed setters. The underlying code path happens to share memory today (the setter is a one-line field assignment in the generated code), but relying on that breaks the API boundary and may not survive a regeneration of the \`.pb.go\` files with stricter opaque semantics.

Switched all four sites to the matching \`SetDefaultValue\` / \`SetValue\` methods.

How found: occult-go-analysis baton pool scan (2026-05-20), detector \`proto_getter_lvalue_assign\`.