### PR TITLE
CXP-537 Add connector-local retry system for intermittent API errors

### DIFF
--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -81,25 +81,25 @@ func (s *ServiceNow) enableUser(ctx context.Context, args *structpb.Struct) (*st
 	l := ctxzap.Extract(ctx)
 
 	if args == nil {
-		return nil, nil, fmt.Errorf("arguments cannot be nil")
+		return nil, nil, fmt.Errorf("baton-servicenow: arguments cannot be nil")
 	}
 
 	if args.Fields == nil {
-		return nil, nil, fmt.Errorf("arguments fields cannot be nil")
+		return nil, nil, fmt.Errorf("baton-servicenow: arguments fields cannot be nil")
 	}
 
 	userId, ok := args.Fields["userId"]
 	if !ok {
-		return nil, nil, fmt.Errorf("missing required argument userId")
+		return nil, nil, fmt.Errorf("baton-servicenow: missing required argument userId")
 	}
 
 	if userId == nil {
-		return nil, nil, fmt.Errorf("userId value cannot be nil")
+		return nil, nil, fmt.Errorf("baton-servicenow: userId value cannot be nil")
 	}
 
 	userIdStr := userId.GetStringValue()
 	if userIdStr == "" {
-		return nil, nil, fmt.Errorf("userId cannot be empty")
+		return nil, nil, fmt.Errorf("baton-servicenow: userId cannot be empty")
 	}
 
 	l.Info("enabling user", zap.String("userId", userIdStr))
@@ -107,7 +107,7 @@ func (s *ServiceNow) enableUser(ctx context.Context, args *structpb.Struct) (*st
 	updatedUser, err := s.client.UpdateUserActiveStatus(ctx, userIdStr, true)
 	if err != nil {
 		l.Error("failed to enable user", zap.String("userId", userIdStr), zap.Error(err))
-		return nil, nil, fmt.Errorf("failed to enable user %s: %w", userIdStr, err)
+		return nil, nil, fmt.Errorf("baton-servicenow: failed to enable user %s: %w", userIdStr, err)
 	}
 
 	success := updatedUser.Active == "true"
@@ -127,25 +127,25 @@ func (s *ServiceNow) disableUser(ctx context.Context, args *structpb.Struct) (*s
 	l := ctxzap.Extract(ctx)
 
 	if args == nil {
-		return nil, nil, fmt.Errorf("arguments cannot be nil")
+		return nil, nil, fmt.Errorf("baton-servicenow: arguments cannot be nil")
 	}
 
 	if args.Fields == nil {
-		return nil, nil, fmt.Errorf("arguments fields cannot be nil")
+		return nil, nil, fmt.Errorf("baton-servicenow: arguments fields cannot be nil")
 	}
 
 	userId, ok := args.Fields["userId"]
 	if !ok {
-		return nil, nil, fmt.Errorf("missing required argument userId")
+		return nil, nil, fmt.Errorf("baton-servicenow: missing required argument userId")
 	}
 
 	if userId == nil {
-		return nil, nil, fmt.Errorf("userId value cannot be nil")
+		return nil, nil, fmt.Errorf("baton-servicenow: userId value cannot be nil")
 	}
 
 	userIdStr := userId.GetStringValue()
 	if userIdStr == "" {
-		return nil, nil, fmt.Errorf("userId cannot be empty")
+		return nil, nil, fmt.Errorf("baton-servicenow: userId cannot be empty")
 	}
 
 	l.Info("disabling user", zap.String("userId", userIdStr))
@@ -153,7 +153,7 @@ func (s *ServiceNow) disableUser(ctx context.Context, args *structpb.Struct) (*s
 	updatedUser, err := s.client.UpdateUserActiveStatus(ctx, userIdStr, false)
 	if err != nil {
 		l.Error("failed to disable user", zap.String("userId", userIdStr), zap.Error(err))
-		return nil, nil, fmt.Errorf("failed to disable user %s: %w", userIdStr, err)
+		return nil, nil, fmt.Errorf("baton-servicenow: failed to disable user %s: %w", userIdStr, err)
 	}
 
 	success := updatedUser.Active == "false"

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -109,7 +109,7 @@ func (s *ServiceNow) Validate(ctx context.Context) (annotations.Annotations, err
 
 	_, _, err := s.client.GetUsers(ctx, pagination)
 	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: current user is not able to list users: %w", err)
+		return nil, fmt.Errorf("baton-servicenow: current user is not able to list users: %w", err)
 	}
 
 	return nil, nil

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -67,7 +67,7 @@ func (g *groupResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagi
 		nil,
 	)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("servicenow-connector: failed to list groups: %w", err)
+		return nil, "", nil, fmt.Errorf("baton-servicenow: failed to list groups: %w", err)
 	}
 
 	nextPage, err := bag.NextToken(nextPageToken)
@@ -124,7 +124,7 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, p
 		},
 	)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("servicenow-connector: failed to list groupMembers: %w", err)
+		return nil, "", nil, fmt.Errorf("baton-servicenow: failed to list groupMembers: %w", err)
 	}
 
 	nextPage, err := bag.NextToken(nextPageToken)
@@ -179,7 +179,7 @@ func (r *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 		servicenow.PaginationVars{Limit: 1},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: failed to get group members for %s: %w", entitlement.Id, err)
+		return nil, fmt.Errorf("baton-servicenow: failed to get group members for %s: %w", entitlement.Id, err)
 	}
 
 	// check if user is already a member of the group
@@ -202,7 +202,7 @@ func (r *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: failed to add user %s to group %s: %w", principal.Id.Resource, groupId, err)
+		return nil, fmt.Errorf("baton-servicenow: failed to add user %s to group %s: %w", principal.Id.Resource, groupId, err)
 	}
 
 	return nil, nil
@@ -230,7 +230,7 @@ func (r *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annota
 		servicenow.PaginationVars{Limit: 1},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: failed to get user roles for %s: %w", grant.Principal.Id.Resource, err)
+		return nil, fmt.Errorf("baton-servicenow: failed to get user roles for %s: %w", grant.Principal.Id.Resource, err)
 	}
 
 	// check if group is empty
@@ -251,7 +251,7 @@ func (r *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annota
 			grpMember.Id,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("servicenow-connector: failed to remove user %s from group: %w", grant.Principal.Id.Resource, err)
+			return nil, fmt.Errorf("baton-servicenow: failed to remove user %s from group: %w", grant.Principal.Id.Resource, err)
 		}
 
 		l.Debug("revoked role from user", zap.String("role", grant.Entitlement.Id))

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -65,7 +65,7 @@ func (r *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagin
 		},
 	)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("servicenow-connector: failed to list roles: %w", err)
+		return nil, "", nil, fmt.Errorf("baton-servicenow: failed to list roles: %w", err)
 	}
 
 	nextPage, err := bag.NextToken(nextPageToken)
@@ -134,7 +134,7 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 			},
 		)
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("servicenow-connector: failed to list users under role %s: %w", resource.Id.Resource, err)
+			return nil, "", nil, fmt.Errorf("baton-servicenow: failed to list users under role %s: %w", resource.Id.Resource, err)
 		}
 
 		err = bag.Next(nextPageToken)
@@ -168,7 +168,7 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 			},
 		)
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("servicenow-connector: failed to list groups under role %s: %w", resource.Id.Resource, err)
+			return nil, "", nil, fmt.Errorf("baton-servicenow: failed to list groups under role %s: %w", resource.Id.Resource, err)
 		}
 
 		err = bag.Next(nextPageToken)
@@ -193,7 +193,7 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 		}
 
 	default:
-		return nil, "", nil, fmt.Errorf("unknown resource type: %s", bag.ResourceTypeID())
+		return nil, "", nil, fmt.Errorf("baton-servicenow: unknown resource type: %s", bag.ResourceTypeID())
 	}
 
 	nextPage, err := bag.Marshal()
@@ -224,13 +224,13 @@ func (r *roleResourceType) GrantToUser(ctx context.Context, l *zap.Logger, princ
 		servicenow.PaginationVars{Limit: 1},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: failed to get user roles for %s: %w", principal, err)
+		return nil, fmt.Errorf("baton-servicenow: failed to get user roles for %s: %w", principal, err)
 	}
 
 	// check if the user already has the role
 	if len(userRoles) > 0 {
 		l.Warn(
-			"servicenow-connector: user already has specified role",
+			"baton-servicenow: user already has specified role",
 			zap.String("user", principal),
 			zap.String("role", roleId),
 		)
@@ -247,7 +247,7 @@ func (r *roleResourceType) GrantToUser(ctx context.Context, l *zap.Logger, princ
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: failed to grant role %s to user %s: %w", roleId, principal, err)
+		return nil, fmt.Errorf("baton-servicenow: failed to grant role %s to user %s: %w", roleId, principal, err)
 	}
 
 	l.Debug("granted role to user", zap.String("role", roleId))
@@ -262,18 +262,18 @@ func (r *roleResourceType) GrantToGroup(ctx context.Context, l *zap.Logger, prin
 		servicenow.PaginationVars{Limit: 1},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: failed to get group roles for %s: %w", principal, err)
+		return nil, fmt.Errorf("baton-servicenow: failed to get group roles for %s: %w", principal, err)
 	}
 
 	// check if the group already has the role
 	if len(groupRoles) > 0 {
 		l.Warn(
-			"servicenow-connector: group already has specified role",
+			"baton-servicenow: group already has specified role",
 			zap.String("group", principal),
 			zap.String("role", roleId),
 		)
 
-		return nil, fmt.Errorf("servicenow-connector: group already has specified role")
+		return nil, fmt.Errorf("baton-servicenow: group already has specified role")
 	}
 
 	// grant the role to the group
@@ -285,7 +285,7 @@ func (r *roleResourceType) GrantToGroup(ctx context.Context, l *zap.Logger, prin
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: failed to grant role %s to group %s: %w", roleId, principal, err)
+		return nil, fmt.Errorf("baton-servicenow: failed to grant role %s to group %s: %w", roleId, principal, err)
 	}
 
 	l.Debug("granted role to group", zap.String("role", roleId))
@@ -300,12 +300,12 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 
 	if !principalIsUser && !principalIsGroup {
 		l.Warn(
-			"servicenow-connector: only users or groups can be granted role membership",
+			"baton-servicenow: only users or groups can be granted role membership",
 			zap.String("principal_type", principal.Id.ResourceType),
 			zap.String("principal_id", principal.Id.Resource),
 		)
 
-		return nil, fmt.Errorf("servicenow-connector: only users or groups can be granted role membership")
+		return nil, fmt.Errorf("baton-servicenow: only users or groups can be granted role membership")
 	}
 
 	roleId := entitlement.Resource.Id.Resource
@@ -330,12 +330,12 @@ func (r *roleResourceType) RevokeFromUser(ctx context.Context, l *zap.Logger, pr
 		servicenow.PaginationVars{Limit: 1},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: failed to get user roles for %s: %w", principal.Id.Resource, err)
+		return nil, fmt.Errorf("baton-servicenow: failed to get user roles for %s: %w", principal.Id.Resource, err)
 	}
 
 	if len(userRoles) == 0 {
 		l.Warn(
-			"servicenow-connector: cannot revoke not existing role from user",
+			"baton-servicenow: cannot revoke not existing role from user",
 			zap.String("user", principal.Id.Resource),
 			zap.String("role", roleId),
 		)
@@ -350,7 +350,7 @@ func (r *roleResourceType) RevokeFromUser(ctx context.Context, l *zap.Logger, pr
 			userRole.Id,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("servicenow-connector: failed to revoke role %s from user %s: %w", roleId, principal.Id.Resource, err)
+			return nil, fmt.Errorf("baton-servicenow: failed to revoke role %s from user %s: %w", roleId, principal.Id.Resource, err)
 		}
 
 		l.Debug("revoked role from user", zap.String("role", roleId))
@@ -368,17 +368,17 @@ func (r *roleResourceType) RevokeFromGroup(ctx context.Context, l *zap.Logger, p
 		servicenow.PaginationVars{Limit: 1},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: failed to get group roles for %s: %w", principal.Id.Resource, err)
+		return nil, fmt.Errorf("baton-servicenow: failed to get group roles for %s: %w", principal.Id.Resource, err)
 	}
 
 	if len(groupRoles) == 0 {
 		l.Warn(
-			"servicenow-connector: cannot revoke not existing role from group",
+			"baton-servicenow: cannot revoke not existing role from group",
 			zap.String("group", principal.Id.Resource),
 			zap.String("role", roleId),
 		)
 
-		return nil, fmt.Errorf("servicenow-connector: cannot revoke not existing role from group")
+		return nil, fmt.Errorf("baton-servicenow: cannot revoke not existing role from group")
 	}
 
 	// revoke all roles (inherited or not) from the group
@@ -388,7 +388,7 @@ func (r *roleResourceType) RevokeFromGroup(ctx context.Context, l *zap.Logger, p
 			groupRole.Id,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("servicenow-connector: failed to revoke role %s from group %s: %w", roleId, principal.Id.Resource, err)
+			return nil, fmt.Errorf("baton-servicenow: failed to revoke role %s from group %s: %w", roleId, principal.Id.Resource, err)
 		}
 
 		l.Debug("revoked role from group", zap.String("role", roleId))
@@ -407,12 +407,12 @@ func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotat
 
 	if !principalIsUser && !principalIsGroup {
 		l.Warn(
-			"servicenow-connector: only users or groups can be revoked role membership",
+			"baton-servicenow: only users or groups can be revoked role membership",
 			zap.String("principal_type", principal.Id.ResourceType),
 			zap.String("principal_id", principal.Id.Resource),
 		)
 
-		return nil, fmt.Errorf("servicenow-connector: only users or groups can be revoked role membership")
+		return nil, fmt.Errorf("baton-servicenow: only users or groups can be revoked role membership")
 	}
 
 	roleId := entitlement.Resource.Id.Resource

--- a/pkg/connector/ticket.go
+++ b/pkg/connector/ticket.go
@@ -41,7 +41,7 @@ func (s *ServiceNow) ListTicketSchemas(ctx context.Context, pt *pagination.Token
 		},
 	)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("servicenow-connector: failed to get catalog items: %w", err)
+		return nil, "", nil, fmt.Errorf("baton-servicenow: failed to get catalog items: %w", err)
 	}
 
 	l.Debug("listing ticket schemas",
@@ -53,7 +53,7 @@ func (s *ServiceNow) ListTicketSchemas(ctx context.Context, pt *pagination.Token
 
 	requestedItemStates, err := s.client.GetServiceCatalogRequestedItemStates(ctx)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("servicenow-connector: failed to get catalog requested item states: %w", err)
+		return nil, "", nil, fmt.Errorf("baton-servicenow: failed to get catalog requested item states: %w", err)
 	}
 
 	ticketStatuses := requestedItemStatesToTicketStatus(requestedItemStates)
@@ -75,11 +75,11 @@ func (s *ServiceNow) ListTicketSchemas(ctx context.Context, pt *pagination.Token
 func (s *ServiceNow) GetTicket(ctx context.Context, ticketId string) (*v2.Ticket, annotations.Annotations, error) {
 	serviceCatalogRequestedItem, err := s.client.GetServiceCatalogRequestItem(ctx, ticketId)
 	if err != nil {
-		return nil, nil, fmt.Errorf("servicenow-connector: failed to get catalog requested item %s: %w", ticketId, err)
+		return nil, nil, fmt.Errorf("baton-servicenow: failed to get catalog requested item %s: %w", ticketId, err)
 	}
 	ticket, annos, err := s.serviceCatalogRequestItemToTicket(ctx, serviceCatalogRequestedItem)
 	if err != nil {
-		return ticket, nil, fmt.Errorf("servicenow-connector: %w", err)
+		return ticket, nil, fmt.Errorf("baton-servicenow: %w", err)
 	}
 
 	return ticket, annos, err
@@ -120,7 +120,7 @@ func (s *ServiceNow) CreateTicket(ctx context.Context, ticket *v2.Ticket, schema
 			if GetVariableTypeAnnotation(cf.Annotations) == servicenow.TypeRequestedFor {
 				val, err = sdkTicket.GetCustomFieldValue(ticketFields[id])
 				if err != nil {
-					return nil, nil, fmt.Errorf("servicenow-connector: failed to get custom field value: %s", id)
+					return nil, nil, fmt.Errorf("baton-servicenow: failed to get custom field value: %s", id)
 				}
 
 				// If "requested_for" variable type is not set, we use the service now user id from the ticket requested for
@@ -162,7 +162,7 @@ func (s *ServiceNow) CreateTicket(ctx context.Context, ticket *v2.Ticket, schema
 
 	serviceCatalogRequestedItem, err := s.client.CreateServiceCatalogRequest(ctx, catalogItemID, createServiceCatalogRequestPayload)
 	if err != nil {
-		return nil, nil, fmt.Errorf("servicenow-connector: failed to create service catalog request %s: %w", catalogItemID, err)
+		return nil, nil, fmt.Errorf("baton-servicenow: failed to create service catalog request %s: %w", catalogItemID, err)
 	}
 	labelErr := s.client.AddLabelsToRequest(ctx, serviceCatalogRequestedItem.Id, ticket.Labels)
 
@@ -173,7 +173,7 @@ func (s *ServiceNow) CreateTicket(ctx context.Context, ticket *v2.Ticket, schema
 		},
 	)
 	if updateErr != nil {
-		updateErr = fmt.Errorf("failed to update catalog requested item description: %w", updateErr)
+		updateErr = fmt.Errorf("baton-servicenow: failed to update catalog requested item description: %w", updateErr)
 	}
 
 	ticket, annos, err := s.serviceCatalogRequestItemToTicket(ctx, serviceCatalogRequestedItem)
@@ -183,7 +183,7 @@ func (s *ServiceNow) CreateTicket(ctx context.Context, ticket *v2.Ticket, schema
 
 	err = multierr.Combine(labelErr, updateErr, err)
 	if err != nil {
-		err = fmt.Errorf("servicenow-connector: %w", err)
+		err = fmt.Errorf("baton-servicenow: %w", err)
 	}
 
 	l.Info("created service catalog request", zap.Any("ticket", ticket), zap.Error(err))
@@ -237,11 +237,11 @@ func (s *ServiceNow) BulkGetTickets(ctx context.Context, request *v2.TicketsServ
 func (s *ServiceNow) GetTicketSchema(ctx context.Context, schemaID string) (*v2.TicketSchema, annotations.Annotations, error) {
 	catalogItem, err := s.client.GetCatalogItem(ctx, schemaID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("servicenow-connector: failed to get catalog item %s: %w", schemaID, err)
+		return nil, nil, fmt.Errorf("baton-servicenow: failed to get catalog item %s: %w", schemaID, err)
 	}
 	requestedItemStates, err := s.client.GetServiceCatalogRequestedItemStates(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("servicenow-connector: failed to get catalog requested item states: %w", err)
+		return nil, nil, fmt.Errorf("baton-servicenow: failed to get catalog requested item states: %w", err)
 	}
 	ticketStatuses := requestedItemStatesToTicketStatus(requestedItemStates)
 	schema, err := s.schemaForCatalogItem(ctx, catalogItem)
@@ -260,7 +260,7 @@ func (s *ServiceNow) schemaForCatalogItem(ctx context.Context, catalogItem *serv
 
 	variables, err := s.client.GetCatalogItemVariablesPlusSets(ctx, catalogItem.Id)
 	if err != nil {
-		return nil, fmt.Errorf("servicenow-connector: failed to get variables (item + sets) for catalog item %s: %w", catalogItem.Id, err)
+		return nil, fmt.Errorf("baton-servicenow: failed to get variables (item + sets) for catalog item %s: %w", catalogItem.Id, err)
 	}
 
 	for _, v := range variables {
@@ -323,7 +323,7 @@ func (s *ServiceNow) serviceCatalogRequestItemToTicket(ctx context.Context, requ
 
 	labels, err := s.client.GetLabelsForRequestedItem(ctx, requestedItem.Id)
 	if err != nil {
-		return t, nil, fmt.Errorf("failed to get labels for requested item %s: %w", requestedItem.Id, err)
+		return t, nil, fmt.Errorf("baton-servicenow: failed to get labels for requested item %s: %w", requestedItem.Id, err)
 	}
 
 	t.Labels = labels

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -82,7 +82,7 @@ func (u *userResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagin
 		},
 	)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("servicenow-connector: failed to list users: %w", err)
+		return nil, "", nil, fmt.Errorf("baton-servicenow: failed to list users: %w", err)
 	}
 
 	nextPage, err := bag.NextToken(nextPageToken)
@@ -142,25 +142,25 @@ func (u *userResourceType) CreateAccount(
 	error) {
 	profile := accountInfo.GetProfile().AsMap()
 	if profile == nil {
-		return nil, nil, nil, fmt.Errorf("missing profile in CreateAccountRequest")
+		return nil, nil, nil, fmt.Errorf("baton-servicenow: missing profile in CreateAccountRequest")
 	}
 
 	userName, ok := profile["username"].(string)
 	if !ok || userName == "" {
-		return nil, nil, nil, fmt.Errorf("missing or invalid 'userName' in profile")
+		return nil, nil, nil, fmt.Errorf("baton-servicenow: missing or invalid 'userName' in profile")
 	}
 
 	email, ok := profile["email"].(string)
 	if !ok || email == "" {
-		return nil, nil, nil, fmt.Errorf("missing or invalid 'email' in profile")
+		return nil, nil, nil, fmt.Errorf("baton-servicenow: missing or invalid 'email' in profile")
 	}
 	firstName, ok := profile["first_name"].(string)
 	if !ok || firstName == "" {
-		return nil, nil, nil, fmt.Errorf("missing or invalid 'first_name' in profile")
+		return nil, nil, nil, fmt.Errorf("baton-servicenow: missing or invalid 'first_name' in profile")
 	}
 	lastName, ok := profile["last_name"].(string)
 	if !ok || lastName == "" {
-		return nil, nil, nil, fmt.Errorf("missing or invalid 'last_name' in profile")
+		return nil, nil, nil, fmt.Errorf("baton-servicenow: missing or invalid 'last_name' in profile")
 	}
 
 	user := map[string]string{
@@ -173,12 +173,12 @@ func (u *userResourceType) CreateAccount(
 
 	createdUser, err := u.client.CreateUserAccount(ctx, user)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create user in ServiceNow: %w", err)
+		return nil, nil, nil, fmt.Errorf("baton-servicenow: failed to create user: %w", err)
 	}
 
 	resource, err := userResource(createdUser)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create Baton resource: %w", err)
+		return nil, nil, nil, fmt.Errorf("baton-servicenow: failed to create user resource: %w", err)
 	}
 
 	return &v2.CreateAccountResponse_SuccessResult{Resource: resource}, nil, nil, nil

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -11,8 +11,11 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/tomnomnom/linkheader"
+	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -386,7 +389,7 @@ func (c *Client) RevokeRoleFromGroup(ctx context.Context, id string) error {
 }
 
 func (c *Client) get(ctx context.Context, urlAddress string, resourceResponse interface{}, reqOptions ...ReqOpt) (string, error) {
-	return c.doRequest(
+	return c.doRequestWithRetry(
 		ctx,
 		urlAddress,
 		http.MethodGet,
@@ -403,7 +406,7 @@ func (c *Client) post(
 	data interface{},
 	requestOptions ...ReqOpt,
 ) error {
-	_, err := c.doRequest(
+	_, err := c.doRequestWithRetry(
 		ctx,
 		urlAddress,
 		http.MethodPost,
@@ -422,7 +425,7 @@ func (c *Client) patch(
 	data interface{},
 	requestOptions ...ReqOpt,
 ) error {
-	_, err := c.doRequest(
+	_, err := c.doRequestWithRetry(
 		ctx,
 		urlAddress,
 		http.MethodPatch,
@@ -440,7 +443,7 @@ func (c *Client) delete(
 	resourceResponse interface{},
 	reqOptions ...ReqOpt,
 ) error {
-	_, err := c.doRequest(
+	_, err := c.doRequestWithRetry(
 		ctx,
 		urlAddress,
 		http.MethodDelete,
@@ -527,7 +530,8 @@ func (c *Client) doRequest(ctx context.Context, urlAddress string, method string
 	}
 
 	if rawResponse.StatusCode >= 300 {
-		return "", status.Errorf(handleStatusCode(rawResponse.StatusCode), "request failed: status code %d", rawResponse.StatusCode)
+		respBody, _ := io.ReadAll(rawResponse.Body)
+		return "", status.Errorf(handleStatusCode(rawResponse.StatusCode), "baton-servicenow: request failed with status %d: %s", rawResponse.StatusCode, string(respBody))
 	}
 
 	if method != http.MethodDelete {
@@ -563,6 +567,69 @@ func (c *Client) doRequest(ctx context.Context, urlAddress string, method string
 	}
 
 	return pageToken, nil
+}
+
+const (
+	maxAuthRetries    = 3
+	authRetryBaseWait = time.Second
+)
+
+// doRequestWithRetry wraps doRequest with a small retry loop for transient 401 responses.
+// On each 401 it logs the ServiceNow error body and waits an increasing delay before retrying.
+func (c *Client) doRequestWithRetry(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (string, error) {
+	l := ctxzap.Extract(ctx)
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAuthRetries+1; attempt++ {
+		if attempt > 1 {
+			delay := time.Duration(attempt-1) * authRetryBaseWait
+			l.Debug("baton-servicenow: retrying request after 401",
+				zap.String("url", urlAddress),
+				zap.String("method", method),
+				zap.Int("attempt", attempt),
+				zap.Int("max_attempts", maxAuthRetries+1),
+				zap.Duration("delay", delay),
+			)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+		}
+
+		pageToken, err := c.doRequest(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
+		if err == nil {
+			if attempt > 1 {
+				l.Debug("baton-servicenow: request succeeded after retry",
+					zap.String("url", urlAddress),
+					zap.String("method", method),
+					zap.Int("attempt", attempt),
+				)
+			}
+			return pageToken, nil
+		}
+
+		if status.Code(err) != codes.Unauthenticated {
+			return "", err
+		}
+
+		l.Debug("baton-servicenow: received 401 unauthorized",
+			zap.String("url", urlAddress),
+			zap.String("method", method),
+			zap.Int("attempt", attempt),
+			zap.Int("max_attempts", maxAuthRetries+1),
+			zap.Error(err),
+		)
+		lastErr = err
+	}
+
+	l.Warn("baton-servicenow: request failed after all retry attempts",
+		zap.String("url", urlAddress),
+		zap.String("method", method),
+		zap.Int("max_attempts", maxAuthRetries+1),
+		zap.Error(lastErr),
+	)
+	return "", lastErr
 }
 
 func (c *Client) CreateUserAccount(ctx context.Context, user any) (*User, error) {

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -623,7 +623,7 @@ func (c *Client) doRequestWithRetry(ctx context.Context, urlAddress string, meth
 		lastErr = err
 	}
 
-	l.Warn("baton-servicenow: request failed after all retry attempts",
+	l.Debug("baton-servicenow: request failed after all retry attempts",
 		zap.String("url", urlAddress),
 		zap.String("method", method),
 		zap.Int("max_attempts", maxAuthRetries+1),


### PR DESCRIPTION
Some customers are experiencing intermittent 401's on some API requests.
As a way to face this issue we included a local retry system in the connector, some extra debug logs and error response improvements 