### PR TITLE
CXH-1906: ServiceNow event feed (near-real-time change detection)

### DIFF
--- a/pkg/connector/event_feed.go
+++ b/pkg/connector/event_feed.go
@@ -111,7 +111,7 @@ func (f *serviceNowEventFeed) revokeDetectionPreflight(ctx context.Context) {
 
 	deletedTables, err := f.fetchAuditDeletedTables(ctx)
 	if err != nil {
-		l.Debug("baton-servicenow: event-feed revoke-detection preflight skipped (check failed)",
+		l.Warn("baton-servicenow: event-feed revoke-detection preflight could not verify revoke capture (sys_properties unreadable); revoke events may be silently missing",
 			zap.Error(err),
 		)
 		return
@@ -376,8 +376,8 @@ func (f *serviceNowEventFeed) fetchPhase(
 
 // occurredAt parses a ServiceNow datetime literal, falling back to now.
 func occurredAt(snDatetime string) *timestamppb.Timestamp {
-	if t, err := time.Parse(snDatetimeLayout, snDatetime); err == nil {
-		return timestamppb.New(t.UTC())
+	if t, err := time.ParseInLocation(snDatetimeLayout, snDatetime, time.UTC); err == nil {
+		return timestamppb.New(t)
 	}
 	return timestamppb.Now()
 }

--- a/pkg/connector/event_feed.go
+++ b/pkg/connector/event_feed.go
@@ -1,0 +1,684 @@
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"sync"
+	"time"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
+	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-servicenow/pkg/servicenow"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// servicenowEventFeedID is the stable identifier for the connector's single
+// near-real-time event feed (the analog of Okta's System Log). It polls several
+// ServiceNow sources, preferring audit-INDEPENDENT ones so detection does not
+// depend on instance audit configuration:
+//   - the membership/assignment join tables for newly created rows (grant-created
+//     events), and sys_audit_delete for their deletes (grant-revoke events);
+//   - sys_user by sys_updated_on for account CREATES and field changes — notably
+//     active=false DISABLES — emitted as RESOURCE_CHANGE; plus sys_audit for
+//     account hard-DELETES (also RESOURCE_CHANGE).
+const servicenowEventFeedID = "servicenow_audit_feed"
+
+// Compile-time assertions that the connector implements the recommended
+// EventProviderV2 interface and that the feed implements EventFeed.
+var (
+	_ connectorbuilder.EventProviderV2 = (*ServiceNow)(nil)
+	_ connectorbuilder.EventFeed       = (*serviceNowEventFeed)(nil)
+)
+
+// snDatetimeLayout is the ServiceNow Table API datetime literal format
+// ("YYYY-MM-DD HH:MM:SS", UTC) used in sysparm_query comparisons.
+const snDatetimeLayout = "2006-01-02 15:04:05"
+
+// eventPageSize bounds the number of audit/membership rows fetched per
+// ListEvents call when the SDK does not specify a page size.
+const eventPageSize = 100
+
+// EventFeeds returns the connector's event feeds. Implementing this (via the
+// EventProviderV2 interface) opts the connector into near-real-time change
+// detection, independent of the periodic full sync.
+func (s *ServiceNow) EventFeeds(ctx context.Context) []connectorbuilder.EventFeed {
+	return []connectorbuilder.EventFeed{
+		newServiceNowEventFeed(s.client),
+	}
+}
+
+// auditDeleteFetcher fetches one page of sys_audit_delete rows (with payload)
+// for the revoke phase. It mirrors Client.GetDeletedSincePayload; a field so
+// tests can inject a hard error to exercise phase isolation.
+type auditDeleteFetcher func(ctx context.Context, tableNames []string, createdSince string, pv servicenow.PaginationVars) ([]servicenow.AuditDeleteRecord, string, error)
+
+// auditFetcher fetches one page of sys_audit rows for the account-change phase.
+// It mirrors Client.GetAuditSince; a field so tests can inject a hard error.
+type auditFetcher func(ctx context.Context, tableNames []string, createdSince string, pv servicenow.PaginationVars) ([]servicenow.AuditRecord, string, error)
+
+// Grant-create phase fetchers (live join tables, no audit dependency). Fields so
+// tests can drive ListEvents without a live client; their errors propagate.
+type (
+	groupMembersFetcher func(ctx context.Context, createdSince string, pv servicenow.PaginationVars) ([]servicenow.GroupMember, string, error)
+	userRolesFetcher    func(ctx context.Context, createdSince string, pv servicenow.PaginationVars) ([]servicenow.UserToRole, string, error)
+	groupRolesFetcher   func(ctx context.Context, createdSince string, pv servicenow.PaginationVars) ([]servicenow.GroupToRole, string, error)
+	// usersChangedFetcher polls sys_user by sys_updated_on (audit-INDEPENDENT):
+	// it returns accounts created or modified at/after the cursor, backing the
+	// account create/disable/modify phase.
+	usersChangedFetcher func(ctx context.Context, changedSince string, pv servicenow.PaginationVars) ([]servicenow.User, string, error)
+)
+
+type serviceNowEventFeed struct {
+	client *servicenow.Client
+
+	// Grant-create phase fetchers (audit-INDEPENDENT real data source).
+	fetchGroupMembers groupMembersFetcher
+	fetchUserRoles    userRolesFetcher
+	fetchGroupRoles   groupRolesFetcher
+	fetchUsersChanged usersChangedFetcher
+
+	// fetchJoinDeletes/fetchAudit back the two AUDIT-DEPENDENT phases. They
+	// default to the client methods and are overridable in tests so a hard fetch
+	// error can be injected to verify those phases are skipped (not fatal) while
+	// the audit-independent grant-create phases keep producing events.
+	fetchJoinDeletes auditDeleteFetcher
+	fetchAudit       auditFetcher
+
+	// fetchAuditDeletedTables backs the revoke-detection preflight: it reads the
+	// glide.ui.audit_deleted_tables system property (the list of tables whose
+	// deletes are captured to sys_audit_delete, the grant-REVOKE source).
+	// Overridable in tests.
+	fetchAuditDeletedTables func(ctx context.Context) ([]string, error)
+
+	// preflightOnce guards the one-time advisory audit-config preflight warnings.
+	preflightOnce sync.Once
+}
+
+func newServiceNowEventFeed(client *servicenow.Client) *serviceNowEventFeed {
+	f := &serviceNowEventFeed{client: client}
+	f.fetchGroupMembers = client.GetGroupMembersCreatedSince
+	f.fetchUserRoles = client.GetUserRolesCreatedSince
+	f.fetchGroupRoles = client.GetGroupRolesCreatedSince
+	f.fetchUsersChanged = func(ctx context.Context, changedSince string, pv servicenow.PaginationVars) ([]servicenow.User, string, error) {
+		return client.GetUsersUpdatedSince(ctx, pv, changedSince)
+	}
+	f.fetchJoinDeletes = func(ctx context.Context, tableNames []string, createdSince string, pv servicenow.PaginationVars) ([]servicenow.AuditDeleteRecord, string, error) {
+		return client.GetDeletedSincePayload(ctx, tableNames, createdSince, pv)
+	}
+	f.fetchAudit = func(ctx context.Context, tableNames []string, createdSince string, pv servicenow.PaginationVars) ([]servicenow.AuditRecord, string, error) {
+		return client.GetAuditSince(ctx, tableNames, createdSince, pv)
+	}
+	f.fetchAuditDeletedTables = client.GetAuditDeletedTables
+	return f
+}
+
+// revokeDetectionTables are the join (grant) tables whose hard deletes must be
+// captured to sys_audit_delete for near-real-time grant-REVOKE events to fire.
+// The signal is the glide.ui.audit_deleted_tables system property: a table's
+// PRESENCE in that list means its deletes are reliably captured.
+var revokeDetectionTables = []string{
+	servicenow.TableUserGroupMember,
+	servicenow.TableUserHasRole,
+	servicenow.TableGroupHasRole,
+}
+
+// auditConfigPreflight runs, at most once per process, a single advisory check so
+// silent non-detection of feed events is visible. It never fails the feed, and any
+// failure of the check itself is swallowed with a debug log.
+//
+// The check is revoke detection (revokeDetectionPreflight). No account-side check
+// is needed: account creates, disables, and other field changes are detected
+// audit-independently by phaseUserChanges (sys_user by sys_updated_on), and
+// account hard-deletes are logged to sys_audit regardless of any audit flag.
+func (f *serviceNowEventFeed) auditConfigPreflight(ctx context.Context) {
+	f.preflightOnce.Do(func() {
+		f.revokeDetectionPreflight(ctx)
+	})
+}
+
+// revokeDetectionPreflight is the feed's audit-config advisory check. It reads the
+// glide.ui.audit_deleted_tables system property — the list of tables whose hard
+// deletes are written to sys_audit_delete, the grant-REVOKE source. For each grant
+// join table (sys_user_grmember / sys_user_has_role / sys_group_has_role): if it is
+// NOT in the list, warn that near-real-time revoke detection is likely off for it
+// (remediation: add the table to glide.ui.audit_deleted_tables; full-sync
+// reconciliation still covers removals).
+func (f *serviceNowEventFeed) revokeDetectionPreflight(ctx context.Context) {
+	l := ctxzap.Extract(ctx)
+
+	deletedTables, err := f.fetchAuditDeletedTables(ctx)
+	if err != nil {
+		l.Debug("baton-servicenow: event-feed revoke-detection preflight skipped (check failed)",
+			zap.Error(err),
+		)
+		return
+	}
+
+	captured := make(map[string]bool, len(deletedTables))
+	for _, t := range deletedTables {
+		captured[t] = true
+	}
+
+	var uncaptured []string
+	for _, t := range revokeDetectionTables {
+		if !captured[t] {
+			uncaptured = append(uncaptured, t)
+		}
+	}
+	if len(uncaptured) == 0 {
+		l.Debug("baton-servicenow: event-feed revoke-detection preflight OK (grant join tables captured to sys_audit_delete)",
+			zap.Strings("tables", revokeDetectionTables),
+		)
+		return
+	}
+
+	l.Warn("baton-servicenow: ServiceNow delete-capture is NOT enabled for grant join table(s); "+
+		"near-real-time grant-REVOKE events are likely OFF for these — full-sync reconciliation "+
+		"still covers removals. Remediation: add the table(s) to the glide.ui.audit_deleted_tables "+
+		"system property so their deletes are recorded in sys_audit_delete.",
+		zap.Strings("uncaptured_tables", uncaptured),
+	)
+}
+
+func (f *serviceNowEventFeed) EventFeedMetadata(ctx context.Context) *v2.EventFeedMetadata {
+	return &v2.EventFeedMetadata{
+		Id: servicenowEventFeedID,
+		SupportedEventTypes: []v2.EventType{
+			v2.EventType_EVENT_TYPE_CREATE_GRANT,
+			v2.EventType_EVENT_TYPE_CREATE_REVOKE,
+			v2.EventType_EVENT_TYPE_RESOURCE_CHANGE,
+		},
+	}
+}
+
+// feedPhase identifies which underlying source the cursor is currently draining.
+// Phases run in a fixed order; the connector drains one phase fully (by offset)
+// before advancing to the next, so the StreamToken cursor encodes (phase,
+// offset).
+type feedPhase int
+
+const (
+	phaseGroupMembers feedPhase = iota // sys_user_grmember -> group "member" grants
+	phaseUserRoles                     // sys_user_has_role  -> role "member" grants
+	phaseGroupRoles                    // sys_group_has_role -> role "member" grants
+	phaseUserChanges                   // sys_user (by sys_updated_on) -> account create/disable/modify (RESOURCE_CHANGE)
+	phaseJoinDeletes                   // sys_audit_delete   -> grant "revoke" events
+	phaseAudit                         // sys_audit          -> account hard-delete (RESOURCE_CHANGE)
+	phaseDone
+)
+
+// isAuditBackedPhase reports whether a phase reads from ServiceNow's audit
+// tables (sys_audit_delete / sys_audit). These phases have a HARD dependency on
+// instance audit configuration and access: a permission/ACL error on those
+// tables must NOT kill the whole multi-source poll. The grant-CREATE phases
+// (live join tables, no audit dependency) are NOT audit-backed — their errors
+// propagate, because they are the real, always-available data source.
+//
+// (Note: "auditing disabled" returns EMPTY rows, not an error, and is already
+// handled by the normal drained-phase path. This classification governs only
+// HARD fetch errors — e.g. ACL/permission denials on the audit tables.)
+func isAuditBackedPhase(p feedPhase) bool {
+	return p == phaseJoinDeletes || p == phaseAudit
+}
+
+// feedCursor is the JSON-encoded StreamToken cursor for the audit feed.
+type feedCursor struct {
+	Phase  feedPhase `json:"phase"`
+	Offset int       `json:"offset"`
+}
+
+func parseFeedCursor(s string) (feedCursor, error) {
+	if s == "" {
+		return feedCursor{Phase: phaseGroupMembers, Offset: 0}, nil
+	}
+	var c feedCursor
+	if err := json.Unmarshal([]byte(s), &c); err != nil {
+		return feedCursor{}, fmt.Errorf("baton-servicenow: invalid event-feed cursor: %w", err)
+	}
+	return c, nil
+}
+
+func (c feedCursor) encode() (string, error) {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return "", fmt.Errorf("baton-servicenow: failed to encode event-feed cursor: %w", err)
+	}
+	return string(b), nil
+}
+
+// ListEvents returns the next page of events at or after earliestEvent. It walks
+// the source tables phase by phase (grant-created phases first, then sys_audit
+// for account/resource changes), using the StreamToken cursor to track the
+// current phase and Table API offset, exactly mirroring Okta's cursor approach.
+func (f *serviceNowEventFeed) ListEvents(
+	ctx context.Context,
+	earliestEvent *timestamppb.Timestamp,
+	pToken *pagination.StreamToken,
+) ([]*v2.Event, *pagination.StreamState, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+
+	// Advisory, never-fatal: warn once per process if instance audit config means
+	// the audit-backed phases (revokes / account changes) can't fire.
+	f.auditConfigPreflight(ctx)
+
+	cursor, err := parseFeedCursor(pToken.Cursor)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	since := ""
+	if earliestEvent != nil {
+		since = earliestEvent.AsTime().UTC().Format(snDatetimeLayout)
+	}
+
+	pageSize := pToken.Size
+	if pageSize <= 0 {
+		pageSize = eventPageSize
+	}
+	pv := servicenow.PaginationVars{Limit: pageSize, Offset: cursor.Offset}
+
+	for cursor.Phase < phaseDone {
+		events, next, err := f.fetchPhase(ctx, cursor.Phase, since, pv)
+		if err != nil {
+			// Phase isolation (we are MULTI-source, unlike okta's single-source
+			// feed): a HARD error on an AUDIT-BACKED phase (locked-down or
+			// inaccessible sys_audit / sys_audit_delete, ACL/permission denial)
+			// must NOT kill the whole poll. Log a warning, advance the cursor PAST
+			// this phase (reset offset), and continue the walk so the always-working
+			// grant-create phases still return their events. The periodic full sync
+			// remains the backstop for the skipped revoke/account-change source.
+			//
+			// Grant-create phases (live join tables, no audit dependency) are the
+			// real data source: their errors still propagate.
+			if isAuditBackedPhase(cursor.Phase) {
+				l.Warn("baton-servicenow: skipping audit-backed event-feed phase after fetch error (full sync will reconcile)",
+					zap.Int("phase", int(cursor.Phase)),
+					zap.Error(err),
+				)
+				cursor.Phase++
+				cursor.Offset = 0
+				pv.Offset = 0
+				continue
+			}
+			return nil, nil, nil, err
+		}
+
+		// More rows in this phase: stay on the phase, advance the offset.
+		if next != "" {
+			off, convErr := servicenow.ConvertPageToken(next)
+			if convErr != nil {
+				return nil, nil, nil, fmt.Errorf("baton-servicenow: failed to parse event-feed page token: %w", convErr)
+			}
+			// Guard against a non-advancing token (treat the phase as drained).
+			if off > cursor.Offset {
+				cursor.Offset = off
+				state, encErr := streamState(cursor, true)
+				if encErr != nil {
+					return nil, nil, nil, encErr
+				}
+				return events, state, nil, nil
+			}
+		}
+
+		// Phase drained: advance to the next phase, reset offset.
+		cursor.Phase++
+		cursor.Offset = 0
+		pv.Offset = 0
+
+		// Return whatever this phase yielded; HasMore stays true until phaseDone.
+		if len(events) > 0 {
+			state, encErr := streamState(cursor, cursor.Phase < phaseDone)
+			if encErr != nil {
+				return nil, nil, nil, encErr
+			}
+			return events, state, nil, nil
+		}
+		l.Debug("baton-servicenow: event-feed phase produced no events, advancing", zap.Int("phase", int(cursor.Phase-1)))
+	}
+
+	// All phases drained.
+	state, err := streamState(feedCursor{Phase: phaseDone}, false)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return []*v2.Event{}, state, nil, nil
+}
+
+func streamState(cursor feedCursor, hasMore bool) (*pagination.StreamState, error) {
+	enc, err := cursor.encode()
+	if err != nil {
+		return nil, err
+	}
+	return &pagination.StreamState{Cursor: enc, HasMore: hasMore}, nil
+}
+
+// fetchPhase fetches one page from the source backing the given phase and maps
+// the rows to events.
+func (f *serviceNowEventFeed) fetchPhase(
+	ctx context.Context,
+	phase feedPhase,
+	since string,
+	pv servicenow.PaginationVars,
+) ([]*v2.Event, string, error) {
+	switch phase {
+	case phaseGroupMembers:
+		rows, next, err := f.fetchGroupMembers(ctx, since, pv)
+		if err != nil {
+			return nil, "", fmt.Errorf("baton-servicenow: failed to list new group memberships: %w", err)
+		}
+		evs := make([]*v2.Event, 0, len(rows))
+		for i := range rows {
+			evs = append(evs, groupMemberCreateGrantEvent(&rows[i]))
+		}
+		return evs, next, nil
+
+	case phaseUserRoles:
+		rows, next, err := f.fetchUserRoles(ctx, since, pv)
+		if err != nil {
+			return nil, "", fmt.Errorf("baton-servicenow: failed to list new user roles: %w", err)
+		}
+		evs := make([]*v2.Event, 0, len(rows))
+		for i := range rows {
+			evs = append(evs, userRoleCreateGrantEvent(&rows[i]))
+		}
+		return evs, next, nil
+
+	case phaseGroupRoles:
+		rows, next, err := f.fetchGroupRoles(ctx, since, pv)
+		if err != nil {
+			return nil, "", fmt.Errorf("baton-servicenow: failed to list new group roles: %w", err)
+		}
+		evs := make([]*v2.Event, 0, len(rows))
+		for i := range rows {
+			evs = append(evs, groupRoleCreateGrantEvent(&rows[i]))
+		}
+		return evs, next, nil
+
+	case phaseUserChanges:
+		rows, next, err := f.fetchUsersChanged(ctx, since, pv)
+		if err != nil {
+			return nil, "", fmt.Errorf("baton-servicenow: failed to list changed users: %w", err)
+		}
+		evs := make([]*v2.Event, 0, len(rows))
+		for i := range rows {
+			evs = append(evs, userChangeEvent(&rows[i]))
+		}
+		return evs, next, nil
+
+	case phaseJoinDeletes:
+		rows, next, err := f.fetchJoinDeletes(ctx, joinDeleteTables, since, pv)
+		if err != nil {
+			return nil, "", fmt.Errorf("baton-servicenow: failed to list deleted grants: %w", err)
+		}
+		evs := make([]*v2.Event, 0, len(rows))
+		for i := range rows {
+			if ev := joinDeleteRevokeEvent(ctx, &rows[i]); ev != nil {
+				evs = append(evs, ev)
+			}
+		}
+		return evs, next, nil
+
+	case phaseAudit:
+		rows, next, err := f.fetchAudit(ctx, servicenow.AuditedTables, since, pv)
+		if err != nil {
+			return nil, "", fmt.Errorf("baton-servicenow: failed to list audit changes: %w", err)
+		}
+		evs := make([]*v2.Event, 0, len(rows))
+		for i := range rows {
+			if ev := auditChangeEvent(&rows[i]); ev != nil {
+				evs = append(evs, ev)
+			}
+		}
+		return evs, next, nil
+
+	default:
+		return nil, "", nil
+	}
+}
+
+// occurredAt parses a ServiceNow datetime literal into a proto timestamp,
+// falling back to the current time if it cannot be parsed.
+func occurredAt(snDatetime string) *timestamppb.Timestamp {
+	if t, err := time.Parse(snDatetimeLayout, snDatetime); err == nil {
+		return timestamppb.New(t.UTC())
+	}
+	return timestamppb.Now()
+}
+
+// groupMemberCreateGrantEvent maps a new sys_user_grmember row to a
+// grant-created event: principal=user, entitlement=group "member".
+func groupMemberCreateGrantEvent(m *servicenow.GroupMember) *v2.Event {
+	groupRes := minimalResource(resourceTypeGroup, m.Group)
+	principal := minimalResource(resourceTypeUser, m.User)
+	return &v2.Event{
+		Id:         "grmember:" + m.Id,
+		OccurredAt: occurredAt(m.SysCreatedOn),
+		Event: &v2.Event_CreateGrantEvent{
+			CreateGrantEvent: &v2.CreateGrantEvent{
+				Entitlement: ent.NewAssignmentEntitlement(groupRes, groupMembership),
+				Principal:   principal,
+			},
+		},
+	}
+}
+
+// userRoleCreateGrantEvent maps a new sys_user_has_role row to a grant-created
+// event: principal=user, entitlement=role "member".
+func userRoleCreateGrantEvent(r *servicenow.UserToRole) *v2.Event {
+	roleRes := minimalResource(resourceTypeRole, r.Role)
+	principal := minimalResource(resourceTypeUser, r.User)
+	return &v2.Event{
+		Id:         "userrole:" + r.Id,
+		OccurredAt: occurredAt(r.SysCreatedOn),
+		Event: &v2.Event_CreateGrantEvent{
+			CreateGrantEvent: &v2.CreateGrantEvent{
+				Entitlement: ent.NewAssignmentEntitlement(roleRes, roleMembership),
+				Principal:   principal,
+			},
+		},
+	}
+}
+
+// groupRoleCreateGrantEvent maps a new sys_group_has_role row to a grant-created
+// event: principal=group, entitlement=role "member".
+func groupRoleCreateGrantEvent(r *servicenow.GroupToRole) *v2.Event {
+	roleRes := minimalResource(resourceTypeRole, r.Role)
+	principal := minimalResource(resourceTypeGroup, r.Group)
+	return &v2.Event{
+		Id:         "grouprole:" + r.Id,
+		OccurredAt: occurredAt(r.SysCreatedOn),
+		Event: &v2.Event_CreateGrantEvent{
+			CreateGrantEvent: &v2.CreateGrantEvent{
+				Entitlement: ent.NewAssignmentEntitlement(roleRes, roleMembership),
+				Principal:   principal,
+			},
+		},
+	}
+}
+
+// joinDeleteTables are the membership/assignment join tables whose hard deletes
+// the event feed turns into revoke events. Other deleted tables (e.g. sys_user)
+// are ignored by the revoke phase (account deletes are reconciled by the sync /
+// surface as a sys_user audit-delete handled elsewhere).
+var joinDeleteTables = []string{
+	servicenow.TableUserGroupMember,
+	servicenow.TableUserHasRole,
+	servicenow.TableGroupHasRole,
+}
+
+// deletedRowPayload is the parsed XML of a sys_audit_delete.payload column. The
+// payload is the full serialization of the deleted row: each column is a child
+// element of the (table-named) root whose text is the column's value, and a
+// reference column's text is the referenced sys_id. We bind every field we may
+// need across the join tables; only the relevant ones are set per table.
+type deletedRowPayload struct {
+	Group string `xml:"group"` // sys_user_grmember / sys_group_has_role
+	User  string `xml:"user"`  // sys_user_grmember / sys_user_has_role
+	Role  string `xml:"role"`  // sys_user_has_role / sys_group_has_role
+}
+
+// parseDeletedRowPayload parses a sys_audit_delete payload XML dump into its
+// reference fields. The root element is the deleted row's table name, so we
+// decode against the generic deletedRowPayload regardless of table.
+func parseDeletedRowPayload(payload string) (*deletedRowPayload, error) {
+	var p deletedRowPayload
+	if err := xml.Unmarshal([]byte(payload), &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// joinDeleteRevokeEvent maps a sys_audit_delete row for one of the join
+// tables to a grant-revoke event, resolving (principal, entitlement) from the
+// deleted row's full XML payload. Returns nil (and logs a warning) for rows it
+// cannot map — a missing/unparseable payload, an unexpected table, or a payload
+// missing the reference fields — so a single bad row never fails the feed.
+func joinDeleteRevokeEvent(ctx context.Context, d *servicenow.AuditDeleteRecord) *v2.Event {
+	l := ctxzap.Extract(ctx)
+
+	if d.Payload == "" {
+		l.Warn("baton-servicenow: skipping deleted grant with empty payload (delete-recovery may be disabled)",
+			zap.String("table", d.Tablename),
+			zap.String("documentkey", d.DocumentKey),
+		)
+		return nil
+	}
+
+	p, err := parseDeletedRowPayload(d.Payload)
+	if err != nil {
+		l.Warn("baton-servicenow: skipping deleted grant with unparseable payload",
+			zap.String("table", d.Tablename),
+			zap.String("documentkey", d.DocumentKey),
+			zap.Error(err),
+		)
+		return nil
+	}
+
+	var principal *v2.Resource
+	var entitlement *v2.Entitlement
+
+	switch d.Tablename {
+	case servicenow.TableUserGroupMember:
+		// principal=user, entitlement=group "member".
+		if p.User == "" || p.Group == "" {
+			break
+		}
+		principal = minimalResource(resourceTypeUser, p.User)
+		entitlement = ent.NewAssignmentEntitlement(minimalResource(resourceTypeGroup, p.Group), groupMembership)
+	case servicenow.TableUserHasRole:
+		// principal=user, entitlement=role "member".
+		if p.User == "" || p.Role == "" {
+			break
+		}
+		principal = minimalResource(resourceTypeUser, p.User)
+		entitlement = ent.NewAssignmentEntitlement(minimalResource(resourceTypeRole, p.Role), roleMembership)
+	case servicenow.TableGroupHasRole:
+		// principal=group, entitlement=role "member".
+		if p.Group == "" || p.Role == "" {
+			break
+		}
+		principal = minimalResource(resourceTypeGroup, p.Group)
+		entitlement = ent.NewAssignmentEntitlement(minimalResource(resourceTypeRole, p.Role), roleMembership)
+	default:
+		// Not a join table we map; ignore quietly.
+		return nil
+	}
+
+	if principal == nil || entitlement == nil {
+		l.Warn("baton-servicenow: skipping deleted grant with incomplete payload references",
+			zap.String("table", d.Tablename),
+			zap.String("documentkey", d.DocumentKey),
+		)
+		return nil
+	}
+
+	return &v2.Event{
+		Id:         "revoke:" + d.DocumentKey,
+		OccurredAt: occurredAt(d.SysCreatedOn),
+		Event: &v2.Event_CreateRevokeEvent{
+			CreateRevokeEvent: &v2.CreateRevokeEvent{
+				Entitlement: entitlement,
+				Principal:   principal,
+			},
+		},
+	}
+}
+
+// auditChangeEvent maps a sys_audit row to a resource-change event when the
+// changed record maps cleanly to a connector resource. In practice this is the
+// account hard-DELETE path: a deleted sys_user writes a sys_audit "DELETED" row
+// (documentkey == user sys_id) regardless of the table's audit flag, which emits
+// a ResourceChangeEvent so ConductorOne re-syncs (and drops) that account.
+// Account creates and field changes — including active=false disables — are
+// covered audit-independently by phaseUserChanges (sys_user by sys_updated_on);
+// if field-change auditing happens to be enabled, those rows would also appear
+// here, producing a duplicate but idempotent ResourceChangeEvent.
+//
+// Rows on the join tables are skipped here (returns nil): their sys_audit
+// documentkey is only the join-row sys_id. Grant CREATIONS are surfaced by the
+// dedicated membership-table phases above, and grant DELETES are surfaced as
+// CreateRevokeEvents by phaseJoinDeletes (which reads sys_audit_delete.payload —
+// the full XML of the deleted row — to resolve the (principal, entitlement)
+// pair, something the sys_audit row alone cannot do).
+func auditChangeEvent(a *servicenow.AuditRecord) *v2.Event {
+	if a.Tablename != servicenow.TableUser {
+		return nil
+	}
+	return &v2.Event{
+		Id:         "audit:" + a.SysID,
+		OccurredAt: occurredAt(a.SysCreatedOn),
+		Event: &v2.Event_ResourceChangeEvent{
+			ResourceChangeEvent: &v2.ResourceChangeEvent{
+				ResourceId: &v2.ResourceId{
+					ResourceType: resourceTypeUser.Id,
+					Resource:     a.DocumentKey,
+				},
+			},
+		},
+	}
+}
+
+// userChangeEvent maps a sys_user row found by polling sys_user by
+// sys_updated_on to a RESOURCE_CHANGE event so ConductorOne re-syncs that
+// account. This is the audit-INDEPENDENT source for account CREATES and field
+// changes — notably active=false DISABLES: ServiceNow writes no sys_audit row
+// for inserts (glide.sys.audit_inserts is false) and writes field-change rows
+// only when table auditing is enabled, so without this phase neither new nor
+// disabled accounts would surface in near-real-time. Account hard-DELETES are
+// covered by phaseAudit instead (the sys_audit "DELETED" row, written regardless
+// of the audit flag); a deleted account no longer exists in sys_user, so it
+// cannot appear here.
+func userChangeEvent(u *servicenow.User) *v2.Event {
+	return &v2.Event{
+		Id:         "userchange:" + u.Id,
+		OccurredAt: occurredAt(u.SysUpdatedOn),
+		Event: &v2.Event_ResourceChangeEvent{
+			ResourceChangeEvent: &v2.ResourceChangeEvent{
+				ResourceId: &v2.ResourceId{
+					ResourceType: resourceTypeUser.Id,
+					Resource:     u.Id,
+				},
+			},
+		},
+	}
+}
+
+// minimalResource builds a resource carrying only its id/type, sufficient for
+// event payloads (ConductorOne resolves full attributes from its synced graph).
+func minimalResource(rt *v2.ResourceType, id string) *v2.Resource {
+	r, err := rs.NewResource(id, rt, id)
+	if err != nil {
+		// NewResource only errors on option application; with no options it
+		// cannot fail, but stay defensive and fall back to a bare resource.
+		return &v2.Resource{Id: &v2.ResourceId{ResourceType: rt.Id, Resource: id}}
+	}
+	return r
+}

--- a/pkg/connector/event_feed.go
+++ b/pkg/connector/event_feed.go
@@ -20,85 +20,54 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// servicenowEventFeedID is the stable identifier for the connector's single
-// near-real-time event feed (the analog of Okta's System Log). It polls several
-// ServiceNow sources, preferring audit-INDEPENDENT ones so detection does not
-// depend on instance audit configuration:
-//   - the membership/assignment join tables for newly created rows (grant-created
-//     events), and sys_audit_delete for their deletes (grant-revoke events);
-//   - sys_user by sys_updated_on for account CREATES and field changes — notably
-//     active=false DISABLES — emitted as RESOURCE_CHANGE; plus sys_audit for
-//     account hard-DELETES (also RESOURCE_CHANGE).
+// servicenowEventFeedID identifies the connector's near-real-time event feed.
 const servicenowEventFeedID = "servicenow_audit_feed"
 
-// Compile-time assertions that the connector implements the recommended
-// EventProviderV2 interface and that the feed implements EventFeed.
 var (
 	_ connectorbuilder.EventProviderV2 = (*ServiceNow)(nil)
 	_ connectorbuilder.EventFeed       = (*serviceNowEventFeed)(nil)
 )
 
-// snDatetimeLayout is the ServiceNow Table API datetime literal format
-// ("YYYY-MM-DD HH:MM:SS", UTC) used in sysparm_query comparisons.
+// snDatetimeLayout is the ServiceNow Table API datetime literal format (UTC).
 const snDatetimeLayout = "2006-01-02 15:04:05"
 
-// eventPageSize bounds the number of audit/membership rows fetched per
-// ListEvents call when the SDK does not specify a page size.
+// eventPageSize is the default rows-per-page when the SDK gives no page size.
 const eventPageSize = 100
 
-// EventFeeds returns the connector's event feeds. Implementing this (via the
-// EventProviderV2 interface) opts the connector into near-real-time change
-// detection, independent of the periodic full sync.
+// EventFeeds returns the connector's event feeds.
 func (s *ServiceNow) EventFeeds(ctx context.Context) []connectorbuilder.EventFeed {
 	return []connectorbuilder.EventFeed{
 		newServiceNowEventFeed(s.client),
 	}
 }
 
-// auditDeleteFetcher fetches one page of sys_audit_delete rows (with payload)
-// for the revoke phase. It mirrors Client.GetDeletedSincePayload; a field so
+// auditDeleteFetcher fetches sys_audit_delete rows (revoke phase); a field so
 // tests can inject a hard error to exercise phase isolation.
 type auditDeleteFetcher func(ctx context.Context, tableNames []string, createdSince string, pv servicenow.PaginationVars) ([]servicenow.AuditDeleteRecord, string, error)
 
-// auditFetcher fetches one page of sys_audit rows for the account-change phase.
-// It mirrors Client.GetAuditSince; a field so tests can inject a hard error.
+// auditFetcher fetches sys_audit rows (account-change phase); injectable in tests.
 type auditFetcher func(ctx context.Context, tableNames []string, createdSince string, pv servicenow.PaginationVars) ([]servicenow.AuditRecord, string, error)
 
-// Grant-create phase fetchers (live join tables, no audit dependency). Fields so
-// tests can drive ListEvents without a live client; their errors propagate.
+// Grant-create / account-change phase fetchers (live tables, no audit dependency).
 type (
 	groupMembersFetcher func(ctx context.Context, createdSince string, pv servicenow.PaginationVars) ([]servicenow.GroupMember, string, error)
 	userRolesFetcher    func(ctx context.Context, createdSince string, pv servicenow.PaginationVars) ([]servicenow.UserToRole, string, error)
 	groupRolesFetcher   func(ctx context.Context, createdSince string, pv servicenow.PaginationVars) ([]servicenow.GroupToRole, string, error)
-	// usersChangedFetcher polls sys_user by sys_updated_on (audit-INDEPENDENT):
-	// it returns accounts created or modified at/after the cursor, backing the
-	// account create/disable/modify phase.
 	usersChangedFetcher func(ctx context.Context, changedSince string, pv servicenow.PaginationVars) ([]servicenow.User, string, error)
 )
 
 type serviceNowEventFeed struct {
 	client *servicenow.Client
 
-	// Grant-create phase fetchers (audit-INDEPENDENT real data source).
 	fetchGroupMembers groupMembersFetcher
 	fetchUserRoles    userRolesFetcher
 	fetchGroupRoles   groupRolesFetcher
 	fetchUsersChanged usersChangedFetcher
+	fetchJoinDeletes  auditDeleteFetcher
+	fetchAudit        auditFetcher
 
-	// fetchJoinDeletes/fetchAudit back the two AUDIT-DEPENDENT phases. They
-	// default to the client methods and are overridable in tests so a hard fetch
-	// error can be injected to verify those phases are skipped (not fatal) while
-	// the audit-independent grant-create phases keep producing events.
-	fetchJoinDeletes auditDeleteFetcher
-	fetchAudit       auditFetcher
-
-	// fetchAuditDeletedTables backs the revoke-detection preflight: it reads the
-	// glide.ui.audit_deleted_tables system property (the list of tables whose
-	// deletes are captured to sys_audit_delete, the grant-REVOKE source).
-	// Overridable in tests.
 	fetchAuditDeletedTables func(ctx context.Context) ([]string, error)
 
-	// preflightOnce guards the one-time advisory audit-config preflight warnings.
 	preflightOnce sync.Once
 }
 
@@ -120,37 +89,23 @@ func newServiceNowEventFeed(client *servicenow.Client) *serviceNowEventFeed {
 	return f
 }
 
-// revokeDetectionTables are the join (grant) tables whose hard deletes must be
-// captured to sys_audit_delete for near-real-time grant-REVOKE events to fire.
-// The signal is the glide.ui.audit_deleted_tables system property: a table's
-// PRESENCE in that list means its deletes are reliably captured.
+// revokeDetectionTables are the grant join tables whose deletes must be captured
+// to sys_audit_delete (signalled by glide.ui.audit_deleted_tables) for revokes.
 var revokeDetectionTables = []string{
 	servicenow.TableUserGroupMember,
 	servicenow.TableUserHasRole,
 	servicenow.TableGroupHasRole,
 }
 
-// auditConfigPreflight runs, at most once per process, a single advisory check so
-// silent non-detection of feed events is visible. It never fails the feed, and any
-// failure of the check itself is swallowed with a debug log.
-//
-// The check is revoke detection (revokeDetectionPreflight). No account-side check
-// is needed: account creates, disables, and other field changes are detected
-// audit-independently by phaseUserChanges (sys_user by sys_updated_on), and
-// account hard-deletes are logged to sys_audit regardless of any audit flag.
+// auditConfigPreflight runs the once-per-process advisory checks; never fatal.
 func (f *serviceNowEventFeed) auditConfigPreflight(ctx context.Context) {
 	f.preflightOnce.Do(func() {
 		f.revokeDetectionPreflight(ctx)
 	})
 }
 
-// revokeDetectionPreflight is the feed's audit-config advisory check. It reads the
-// glide.ui.audit_deleted_tables system property — the list of tables whose hard
-// deletes are written to sys_audit_delete, the grant-REVOKE source. For each grant
-// join table (sys_user_grmember / sys_user_has_role / sys_group_has_role): if it is
-// NOT in the list, warn that near-real-time revoke detection is likely off for it
-// (remediation: add the table to glide.ui.audit_deleted_tables; full-sync
-// reconciliation still covers removals).
+// revokeDetectionPreflight warns if any grant join table is absent from
+// glide.ui.audit_deleted_tables, meaning its deletes (revokes) won't be captured.
 func (f *serviceNowEventFeed) revokeDetectionPreflight(ctx context.Context) {
 	l := ctxzap.Extract(ctx)
 
@@ -199,37 +154,27 @@ func (f *serviceNowEventFeed) EventFeedMetadata(ctx context.Context) *v2.EventFe
 	}
 }
 
-// feedPhase identifies which underlying source the cursor is currently draining.
-// Phases run in a fixed order; the connector drains one phase fully (by offset)
-// before advancing to the next, so the StreamToken cursor encodes (phase,
-// offset).
+// feedPhase selects a source table. Phases run in a fixed order; the cursor
+// drains one fully (by offset) before advancing, so it encodes (phase, offset).
 type feedPhase int
 
 const (
 	phaseGroupMembers feedPhase = iota // sys_user_grmember -> group "member" grants
 	phaseUserRoles                     // sys_user_has_role  -> role "member" grants
 	phaseGroupRoles                    // sys_group_has_role -> role "member" grants
-	phaseUserChanges                   // sys_user (by sys_updated_on) -> account create/disable/modify (RESOURCE_CHANGE)
+	phaseUserChanges                   // sys_user (by sys_updated_on) -> account create/disable/modify
 	phaseJoinDeletes                   // sys_audit_delete   -> grant "revoke" events
-	phaseAudit                         // sys_audit          -> account hard-delete (RESOURCE_CHANGE)
+	phaseAudit                         // sys_audit          -> account hard-delete
 	phaseDone
 )
 
-// isAuditBackedPhase reports whether a phase reads from ServiceNow's audit
-// tables (sys_audit_delete / sys_audit). These phases have a HARD dependency on
-// instance audit configuration and access: a permission/ACL error on those
-// tables must NOT kill the whole multi-source poll. The grant-CREATE phases
-// (live join tables, no audit dependency) are NOT audit-backed — their errors
-// propagate, because they are the real, always-available data source.
-//
-// (Note: "auditing disabled" returns EMPTY rows, not an error, and is already
-// handled by the normal drained-phase path. This classification governs only
-// HARD fetch errors — e.g. ACL/permission denials on the audit tables.)
+// isAuditBackedPhase reports phases reading the audit tables. A hard error there
+// (e.g. ACL denial) is skipped not fatal; grant-create phases instead propagate.
 func isAuditBackedPhase(p feedPhase) bool {
 	return p == phaseJoinDeletes || p == phaseAudit
 }
 
-// feedCursor is the JSON-encoded StreamToken cursor for the audit feed.
+// feedCursor is the JSON-encoded StreamToken cursor for the feed.
 type feedCursor struct {
 	Phase  feedPhase `json:"phase"`
 	Offset int       `json:"offset"`
@@ -254,10 +199,8 @@ func (c feedCursor) encode() (string, error) {
 	return string(b), nil
 }
 
-// ListEvents returns the next page of events at or after earliestEvent. It walks
-// the source tables phase by phase (grant-created phases first, then sys_audit
-// for account/resource changes), using the StreamToken cursor to track the
-// current phase and Table API offset, exactly mirroring Okta's cursor approach.
+// ListEvents returns the next page of events at or after earliestEvent, walking
+// the source tables phase by phase via the (phase, offset) StreamToken cursor.
 func (f *serviceNowEventFeed) ListEvents(
 	ctx context.Context,
 	earliestEvent *timestamppb.Timestamp,
@@ -265,8 +208,6 @@ func (f *serviceNowEventFeed) ListEvents(
 ) ([]*v2.Event, *pagination.StreamState, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
 
-	// Advisory, never-fatal: warn once per process if instance audit config means
-	// the audit-backed phases (revokes / account changes) can't fire.
 	f.auditConfigPreflight(ctx)
 
 	cursor, err := parseFeedCursor(pToken.Cursor)
@@ -288,16 +229,8 @@ func (f *serviceNowEventFeed) ListEvents(
 	for cursor.Phase < phaseDone {
 		events, next, err := f.fetchPhase(ctx, cursor.Phase, since, pv)
 		if err != nil {
-			// Phase isolation (we are MULTI-source, unlike okta's single-source
-			// feed): a HARD error on an AUDIT-BACKED phase (locked-down or
-			// inaccessible sys_audit / sys_audit_delete, ACL/permission denial)
-			// must NOT kill the whole poll. Log a warning, advance the cursor PAST
-			// this phase (reset offset), and continue the walk so the always-working
-			// grant-create phases still return their events. The periodic full sync
-			// remains the backstop for the skipped revoke/account-change source.
-			//
-			// Grant-create phases (live join tables, no audit dependency) are the
-			// real data source: their errors still propagate.
+			// Phase isolation: a hard error on an audit-backed phase is logged and
+			// skipped (full sync reconciles); grant-create phase errors propagate.
 			if isAuditBackedPhase(cursor.Phase) {
 				l.Warn("baton-servicenow: skipping audit-backed event-feed phase after fetch error (full sync will reconcile)",
 					zap.Int("phase", int(cursor.Phase)),
@@ -333,7 +266,6 @@ func (f *serviceNowEventFeed) ListEvents(
 		cursor.Offset = 0
 		pv.Offset = 0
 
-		// Return whatever this phase yielded; HasMore stays true until phaseDone.
 		if len(events) > 0 {
 			state, encErr := streamState(cursor, cursor.Phase < phaseDone)
 			if encErr != nil {
@@ -344,7 +276,6 @@ func (f *serviceNowEventFeed) ListEvents(
 		l.Debug("baton-servicenow: event-feed phase produced no events, advancing", zap.Int("phase", int(cursor.Phase-1)))
 	}
 
-	// All phases drained.
 	state, err := streamState(feedCursor{Phase: phaseDone}, false)
 	if err != nil {
 		return nil, nil, nil, err
@@ -360,8 +291,7 @@ func streamState(cursor feedCursor, hasMore bool) (*pagination.StreamState, erro
 	return &pagination.StreamState{Cursor: enc, HasMore: hasMore}, nil
 }
 
-// fetchPhase fetches one page from the source backing the given phase and maps
-// the rows to events.
+// fetchPhase fetches one page from the given phase's source and maps it to events.
 func (f *serviceNowEventFeed) fetchPhase(
 	ctx context.Context,
 	phase feedPhase,
@@ -444,8 +374,7 @@ func (f *serviceNowEventFeed) fetchPhase(
 	}
 }
 
-// occurredAt parses a ServiceNow datetime literal into a proto timestamp,
-// falling back to the current time if it cannot be parsed.
+// occurredAt parses a ServiceNow datetime literal, falling back to now.
 func occurredAt(snDatetime string) *timestamppb.Timestamp {
 	if t, err := time.Parse(snDatetimeLayout, snDatetime); err == nil {
 		return timestamppb.New(t.UTC())
@@ -453,8 +382,7 @@ func occurredAt(snDatetime string) *timestamppb.Timestamp {
 	return timestamppb.Now()
 }
 
-// groupMemberCreateGrantEvent maps a new sys_user_grmember row to a
-// grant-created event: principal=user, entitlement=group "member".
+// groupMemberCreateGrantEvent: new sys_user_grmember -> user granted group "member".
 func groupMemberCreateGrantEvent(m *servicenow.GroupMember) *v2.Event {
 	groupRes := minimalResource(resourceTypeGroup, m.Group)
 	principal := minimalResource(resourceTypeUser, m.User)
@@ -470,8 +398,7 @@ func groupMemberCreateGrantEvent(m *servicenow.GroupMember) *v2.Event {
 	}
 }
 
-// userRoleCreateGrantEvent maps a new sys_user_has_role row to a grant-created
-// event: principal=user, entitlement=role "member".
+// userRoleCreateGrantEvent: new sys_user_has_role -> user granted role "member".
 func userRoleCreateGrantEvent(r *servicenow.UserToRole) *v2.Event {
 	roleRes := minimalResource(resourceTypeRole, r.Role)
 	principal := minimalResource(resourceTypeUser, r.User)
@@ -487,8 +414,7 @@ func userRoleCreateGrantEvent(r *servicenow.UserToRole) *v2.Event {
 	}
 }
 
-// groupRoleCreateGrantEvent maps a new sys_group_has_role row to a grant-created
-// event: principal=group, entitlement=role "member".
+// groupRoleCreateGrantEvent: new sys_group_has_role -> group granted role "member".
 func groupRoleCreateGrantEvent(r *servicenow.GroupToRole) *v2.Event {
 	roleRes := minimalResource(resourceTypeRole, r.Role)
 	principal := minimalResource(resourceTypeGroup, r.Group)
@@ -504,30 +430,21 @@ func groupRoleCreateGrantEvent(r *servicenow.GroupToRole) *v2.Event {
 	}
 }
 
-// joinDeleteTables are the membership/assignment join tables whose hard deletes
-// the event feed turns into revoke events. Other deleted tables (e.g. sys_user)
-// are ignored by the revoke phase (account deletes are reconciled by the sync /
-// surface as a sys_user audit-delete handled elsewhere).
+// joinDeleteTables are the grant join tables whose hard deletes become revokes.
 var joinDeleteTables = []string{
 	servicenow.TableUserGroupMember,
 	servicenow.TableUserHasRole,
 	servicenow.TableGroupHasRole,
 }
 
-// deletedRowPayload is the parsed XML of a sys_audit_delete.payload column. The
-// payload is the full serialization of the deleted row: each column is a child
-// element of the (table-named) root whose text is the column's value, and a
-// reference column's text is the referenced sys_id. We bind every field we may
-// need across the join tables; only the relevant ones are set per table.
+// deletedRowPayload holds the reference fields parsed from a
+// sys_audit_delete.payload XML dump of a deleted join row.
 type deletedRowPayload struct {
-	Group string `xml:"group"` // sys_user_grmember / sys_group_has_role
-	User  string `xml:"user"`  // sys_user_grmember / sys_user_has_role
-	Role  string `xml:"role"`  // sys_user_has_role / sys_group_has_role
+	Group string `xml:"group"`
+	User  string `xml:"user"`
+	Role  string `xml:"role"`
 }
 
-// parseDeletedRowPayload parses a sys_audit_delete payload XML dump into its
-// reference fields. The root element is the deleted row's table name, so we
-// decode against the generic deletedRowPayload regardless of table.
 func parseDeletedRowPayload(payload string) (*deletedRowPayload, error) {
 	var p deletedRowPayload
 	if err := xml.Unmarshal([]byte(payload), &p); err != nil {
@@ -536,11 +453,9 @@ func parseDeletedRowPayload(payload string) (*deletedRowPayload, error) {
 	return &p, nil
 }
 
-// joinDeleteRevokeEvent maps a sys_audit_delete row for one of the join
-// tables to a grant-revoke event, resolving (principal, entitlement) from the
-// deleted row's full XML payload. Returns nil (and logs a warning) for rows it
-// cannot map — a missing/unparseable payload, an unexpected table, or a payload
-// missing the reference fields — so a single bad row never fails the feed.
+// joinDeleteRevokeEvent maps a sys_audit_delete row to a grant-revoke event,
+// resolving principal+entitlement from the deleted row's XML payload (the bare
+// sys_audit row can't). Returns nil + warns for any row it cannot map.
 func joinDeleteRevokeEvent(ctx context.Context, d *servicenow.AuditDeleteRecord) *v2.Event {
 	l := ctxzap.Extract(ctx)
 
@@ -567,28 +482,24 @@ func joinDeleteRevokeEvent(ctx context.Context, d *servicenow.AuditDeleteRecord)
 
 	switch d.Tablename {
 	case servicenow.TableUserGroupMember:
-		// principal=user, entitlement=group "member".
 		if p.User == "" || p.Group == "" {
 			break
 		}
 		principal = minimalResource(resourceTypeUser, p.User)
 		entitlement = ent.NewAssignmentEntitlement(minimalResource(resourceTypeGroup, p.Group), groupMembership)
 	case servicenow.TableUserHasRole:
-		// principal=user, entitlement=role "member".
 		if p.User == "" || p.Role == "" {
 			break
 		}
 		principal = minimalResource(resourceTypeUser, p.User)
 		entitlement = ent.NewAssignmentEntitlement(minimalResource(resourceTypeRole, p.Role), roleMembership)
 	case servicenow.TableGroupHasRole:
-		// principal=group, entitlement=role "member".
 		if p.Group == "" || p.Role == "" {
 			break
 		}
 		principal = minimalResource(resourceTypeGroup, p.Group)
 		entitlement = ent.NewAssignmentEntitlement(minimalResource(resourceTypeRole, p.Role), roleMembership)
 	default:
-		// Not a join table we map; ignore quietly.
 		return nil
 	}
 
@@ -612,22 +523,10 @@ func joinDeleteRevokeEvent(ctx context.Context, d *servicenow.AuditDeleteRecord)
 	}
 }
 
-// auditChangeEvent maps a sys_audit row to a resource-change event when the
-// changed record maps cleanly to a connector resource. In practice this is the
-// account hard-DELETE path: a deleted sys_user writes a sys_audit "DELETED" row
-// (documentkey == user sys_id) regardless of the table's audit flag, which emits
-// a ResourceChangeEvent so ConductorOne re-syncs (and drops) that account.
-// Account creates and field changes — including active=false disables — are
-// covered audit-independently by phaseUserChanges (sys_user by sys_updated_on);
-// if field-change auditing happens to be enabled, those rows would also appear
-// here, producing a duplicate but idempotent ResourceChangeEvent.
-//
-// Rows on the join tables are skipped here (returns nil): their sys_audit
-// documentkey is only the join-row sys_id. Grant CREATIONS are surfaced by the
-// dedicated membership-table phases above, and grant DELETES are surfaced as
-// CreateRevokeEvents by phaseJoinDeletes (which reads sys_audit_delete.payload —
-// the full XML of the deleted row — to resolve the (principal, entitlement)
-// pair, something the sys_audit row alone cannot do).
+// auditChangeEvent handles the account hard-DELETE path: a deleted sys_user
+// writes a sys_audit "DELETED" row regardless of the audit flag, emitting a
+// RESOURCE_CHANGE so ConductorOne re-syncs (and drops) the account. Join-table
+// rows are skipped (their documentkey is only the join-row sys_id).
 func auditChangeEvent(a *servicenow.AuditRecord) *v2.Event {
 	if a.Tablename != servicenow.TableUser {
 		return nil
@@ -646,16 +545,10 @@ func auditChangeEvent(a *servicenow.AuditRecord) *v2.Event {
 	}
 }
 
-// userChangeEvent maps a sys_user row found by polling sys_user by
-// sys_updated_on to a RESOURCE_CHANGE event so ConductorOne re-syncs that
-// account. This is the audit-INDEPENDENT source for account CREATES and field
-// changes — notably active=false DISABLES: ServiceNow writes no sys_audit row
-// for inserts (glide.sys.audit_inserts is false) and writes field-change rows
-// only when table auditing is enabled, so without this phase neither new nor
-// disabled accounts would surface in near-real-time. Account hard-DELETES are
-// covered by phaseAudit instead (the sys_audit "DELETED" row, written regardless
-// of the audit flag); a deleted account no longer exists in sys_user, so it
-// cannot appear here.
+// userChangeEvent is the audit-INDEPENDENT account source: polling sys_user by
+// sys_updated_on catches creates and field changes (notably active=false
+// disables) that sys_audit misses (no insert auditing; sys_user auditing off by
+// default). Hard-deletes are handled by phaseAudit instead.
 func userChangeEvent(u *servicenow.User) *v2.Event {
 	return &v2.Event{
 		Id:         "userchange:" + u.Id,
@@ -671,13 +564,10 @@ func userChangeEvent(u *servicenow.User) *v2.Event {
 	}
 }
 
-// minimalResource builds a resource carrying only its id/type, sufficient for
-// event payloads (ConductorOne resolves full attributes from its synced graph).
+// minimalResource builds an id/type-only resource, sufficient for event payloads.
 func minimalResource(rt *v2.ResourceType, id string) *v2.Resource {
 	r, err := rs.NewResource(id, rt, id)
 	if err != nil {
-		// NewResource only errors on option application; with no options it
-		// cannot fail, but stay defensive and fall back to a bare resource.
 		return &v2.Resource{Id: &v2.ResourceId{ResourceType: rt.Id, Resource: id}}
 	}
 	return r

--- a/pkg/connector/event_feed.go
+++ b/pkg/connector/event_feed.go
@@ -349,15 +349,20 @@ func (f *serviceNowEventFeed) fetchPhase(
 			return nil, "", fmt.Errorf("baton-servicenow: failed to list deleted grants: %w", err)
 		}
 		evs := make([]*v2.Event, 0, len(rows))
+		skips := map[string]int{}
 		for i := range rows {
-			if ev := joinDeleteRevokeEvent(ctx, &rows[i]); ev != nil {
+			ev, skipReason := joinDeleteRevokeEvent(&rows[i])
+			if ev != nil {
 				evs = append(evs, ev)
+			} else if skipReason != "" {
+				skips[skipReason]++
 			}
 		}
+		logSkippedDeletes(ctx, skips)
 		return evs, next, nil
 
 	case phaseAudit:
-		rows, next, err := f.fetchAudit(ctx, servicenow.AuditedTables, since, pv)
+		rows, next, err := f.fetchAudit(ctx, auditChangeTables, since, pv)
 		if err != nil {
 			return nil, "", fmt.Errorf("baton-servicenow: failed to list audit changes: %w", err)
 		}
@@ -437,6 +442,11 @@ var joinDeleteTables = []string{
 	servicenow.TableGroupHasRole,
 }
 
+// auditChangeTables scopes the sys_audit phase to sys_user. Only account
+// hard-deletes map to an event (auditChangeEvent); audit rows for the other
+// tables would be paged through and discarded, so we never fetch them.
+var auditChangeTables = []string{servicenow.TableUser}
+
 // deletedRowPayload holds the reference fields parsed from a
 // sys_audit_delete.payload XML dump of a deleted join row.
 type deletedRowPayload struct {
@@ -455,26 +465,18 @@ func parseDeletedRowPayload(payload string) (*deletedRowPayload, error) {
 
 // joinDeleteRevokeEvent maps a sys_audit_delete row to a grant-revoke event,
 // resolving principal+entitlement from the deleted row's XML payload (the bare
-// sys_audit row can't). Returns nil + warns for any row it cannot map.
-func joinDeleteRevokeEvent(ctx context.Context, d *servicenow.AuditDeleteRecord) *v2.Event {
-	l := ctxzap.Extract(ctx)
-
+// sys_audit row can't). Returns (nil, reason) for any row it cannot map; the
+// caller aggregates the reasons so a drain full of unmappable rows logs a few
+// summary lines instead of one warning per row. A reason of "" means the row
+// was for an unrelated table and is silently ignored.
+func joinDeleteRevokeEvent(d *servicenow.AuditDeleteRecord) (*v2.Event, string) {
 	if d.Payload == "" {
-		l.Warn("baton-servicenow: skipping deleted grant with empty payload (delete-recovery may be disabled)",
-			zap.String("table", d.Tablename),
-			zap.String("documentkey", d.DocumentKey),
-		)
-		return nil
+		return nil, "empty payload (delete-recovery may be disabled)"
 	}
 
 	p, err := parseDeletedRowPayload(d.Payload)
 	if err != nil {
-		l.Warn("baton-servicenow: skipping deleted grant with unparseable payload",
-			zap.String("table", d.Tablename),
-			zap.String("documentkey", d.DocumentKey),
-			zap.Error(err),
-		)
-		return nil
+		return nil, "unparseable payload"
 	}
 
 	var principal *v2.Resource
@@ -500,15 +502,11 @@ func joinDeleteRevokeEvent(ctx context.Context, d *servicenow.AuditDeleteRecord)
 		principal = minimalResource(resourceTypeGroup, p.Group)
 		entitlement = ent.NewAssignmentEntitlement(minimalResource(resourceTypeRole, p.Role), roleMembership)
 	default:
-		return nil
+		return nil, ""
 	}
 
 	if principal == nil || entitlement == nil {
-		l.Warn("baton-servicenow: skipping deleted grant with incomplete payload references",
-			zap.String("table", d.Tablename),
-			zap.String("documentkey", d.DocumentKey),
-		)
-		return nil
+		return nil, "incomplete payload references"
 	}
 
 	return &v2.Event{
@@ -520,6 +518,23 @@ func joinDeleteRevokeEvent(ctx context.Context, d *servicenow.AuditDeleteRecord)
 				Principal:   principal,
 			},
 		},
+	}, ""
+}
+
+// logSkippedDeletes emits one Warn per distinct skip reason for a page of
+// sys_audit_delete rows, with the count, so a drain where delete-recovery is
+// off (every row has an empty payload) logs a handful of lines instead of one
+// per row.
+func logSkippedDeletes(ctx context.Context, skips map[string]int) {
+	if len(skips) == 0 {
+		return
+	}
+	l := ctxzap.Extract(ctx)
+	for reason, n := range skips {
+		l.Warn("baton-servicenow: skipped unmappable deleted-grant rows in event feed",
+			zap.String("reason", reason),
+			zap.Int("count", n),
+		)
 	}
 }
 

--- a/pkg/connector/event_feed_test.go
+++ b/pkg/connector/event_feed_test.go
@@ -216,7 +216,7 @@ func TestJoinDeleteRevokeEvent_GroupMember(t *testing.T) {
 		SysCreatedOn: "2026-06-18 16:00:00",
 		Payload:      grmemberDeletePayload,
 	}
-	ev := joinDeleteRevokeEvent(context.Background(), d)
+	ev, _ := joinDeleteRevokeEvent(d)
 	if ev == nil {
 		t.Fatal("expected a revoke event")
 	}
@@ -248,7 +248,7 @@ func TestJoinDeleteRevokeEvent_UserHasRole(t *testing.T) {
 		DocumentKey: "join2",
 		Payload:     userHasRoleDeletePayload,
 	}
-	ev := joinDeleteRevokeEvent(context.Background(), d)
+	ev, _ := joinDeleteRevokeEvent(d)
 	if ev == nil {
 		t.Fatal("expected a revoke event")
 	}
@@ -271,7 +271,7 @@ func TestJoinDeleteRevokeEvent_GroupHasRole(t *testing.T) {
 		DocumentKey: "join3",
 		Payload:     groupHasRoleDeletePayload,
 	}
-	ev := joinDeleteRevokeEvent(context.Background(), d)
+	ev, _ := joinDeleteRevokeEvent(d)
 	if ev == nil {
 		t.Fatal("expected a revoke event")
 	}
@@ -295,7 +295,7 @@ func TestJoinDeleteRevokeEvent_EmptyPayloadSkipped(t *testing.T) {
 		DocumentKey: "join5",
 		Payload:     "",
 	}
-	if ev := joinDeleteRevokeEvent(context.Background(), d); ev != nil {
+	if ev, _ := joinDeleteRevokeEvent(d); ev != nil {
 		t.Fatalf("expected nil for empty payload, got %v", ev)
 	}
 }
@@ -306,7 +306,7 @@ func TestJoinDeleteRevokeEvent_UnparseablePayloadSkipped(t *testing.T) {
 		DocumentKey: "join6",
 		Payload:     "<not-valid-xml<<<",
 	}
-	if ev := joinDeleteRevokeEvent(context.Background(), d); ev != nil {
+	if ev, _ := joinDeleteRevokeEvent(d); ev != nil {
 		t.Fatalf("expected nil for unparseable payload, got %v", ev)
 	}
 }
@@ -318,7 +318,7 @@ func TestJoinDeleteRevokeEvent_IncompletePayloadSkipped(t *testing.T) {
 		DocumentKey: "join7",
 		Payload:     `<sys_user_grmember><user>u1</user></sys_user_grmember>`,
 	}
-	if ev := joinDeleteRevokeEvent(context.Background(), d); ev != nil {
+	if ev, _ := joinDeleteRevokeEvent(d); ev != nil {
 		t.Fatalf("expected nil for incomplete payload, got %v", ev)
 	}
 }
@@ -329,8 +329,58 @@ func TestJoinDeleteRevokeEvent_UnknownTableSkipped(t *testing.T) {
 		DocumentKey: "u1",
 		Payload:     `<sys_user><user_name>jdoe</user_name></sys_user>`,
 	}
-	if ev := joinDeleteRevokeEvent(context.Background(), d); ev != nil {
+	if ev, _ := joinDeleteRevokeEvent(d); ev != nil {
 		t.Fatalf("expected nil for non-join table, got %v", ev)
+	}
+}
+
+// TestEventFeed_DeleteSkipsAggregatedPerPage verifies that a page full of
+// unmappable sys_audit_delete rows (e.g. delete-recovery disabled, so every
+// payload is empty) produces a single aggregated Warn with a count, not one
+// Warn per row.
+func TestEventFeed_DeleteSkipsAggregatedPerPage(t *testing.T) {
+	ctx, logs := ctxWithObservedLogs(t)
+	f := emptyFetchersFeed()
+	f.fetchJoinDeletes = func(_ context.Context, _ []string, _ string, _ servicenow.PaginationVars) ([]servicenow.AuditDeleteRecord, string, error) {
+		rows := make([]servicenow.AuditDeleteRecord, 5)
+		for i := range rows {
+			rows[i] = servicenow.AuditDeleteRecord{Tablename: servicenow.TableUserGroupMember, DocumentKey: "k", Payload: ""}
+		}
+		return rows, "", nil
+	}
+
+	events, _, err := f.fetchPhase(ctx, phaseJoinDeletes, "", servicenow.PaginationVars{Limit: 100})
+	if err != nil {
+		t.Fatalf("fetchPhase: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events (all rows unmappable), got %d", len(events))
+	}
+	warns := logs.FilterLevelExact(zapcore.WarnLevel).
+		FilterMessageSnippet("skipped unmappable deleted-grant rows").All()
+	if len(warns) != 1 {
+		t.Fatalf("expected exactly 1 aggregated warn for 5 skipped rows, got %d", len(warns))
+	}
+	if c := warns[0].ContextMap()["count"]; c != int64(5) {
+		t.Fatalf("expected aggregated count=5, got %v", c)
+	}
+}
+
+// TestEventFeed_AuditPhaseQueriesOnlySysUser verifies the audit phase queries
+// only sys_user (the sole table that maps to an event) rather than all of
+// AuditedTables.
+func TestEventFeed_AuditPhaseQueriesOnlySysUser(t *testing.T) {
+	var gotTables []string
+	f := emptyFetchersFeed()
+	f.fetchAudit = func(_ context.Context, tableNames []string, _ string, _ servicenow.PaginationVars) ([]servicenow.AuditRecord, string, error) {
+		gotTables = tableNames
+		return nil, "", nil
+	}
+	if _, _, err := f.fetchPhase(context.Background(), phaseAudit, "", servicenow.PaginationVars{Limit: 100}); err != nil {
+		t.Fatalf("fetchPhase: %v", err)
+	}
+	if len(gotTables) != 1 || gotTables[0] != servicenow.TableUser {
+		t.Fatalf("audit phase must query only sys_user, got %v", gotTables)
 	}
 }
 

--- a/pkg/connector/event_feed_test.go
+++ b/pkg/connector/event_feed_test.go
@@ -195,9 +195,9 @@ func TestAuditChangeEvent_NonUserSkipped(t *testing.T) {
 	}
 }
 
-// Real sys_audit_delete.payload XML samples verified on dev289997. Each
-// reference field is an element whose TEXT is the referenced sys_id (with a
-// display_value attribute we ignore).
+// Representative sys_audit_delete.payload XML samples. Each reference field is
+// an element whose TEXT is the referenced sys_id (with a display_value
+// attribute we ignore).
 const (
 	grmemberDeletePayload = `<sys_user_grmember><group display_value="G">5338c33d83290f5442cb56d6feaad3d9</group>` +
 		`<user display_value="U">0738c33d83290f5442cb56d6feaad3d1</user></sys_user_grmember>`
@@ -527,8 +527,8 @@ func TestListEvents_SkippedPhaseCursorAdvances(t *testing.T) {
 
 // --- Check 1: revoke detection (glide.ui.audit_deleted_tables) ---
 
-// joinTablesPresent is the real dev289997 property value (the three grant join
-// tables ARE present, so no revoke warning should fire).
+// joinTablesPresent returns the property value where all three grant join
+// tables ARE present, so no revoke warning should fire.
 func joinTablesPresent() []string {
 	return []string{
 		servicenow.TableUserGroupMember,

--- a/pkg/connector/event_feed_test.go
+++ b/pkg/connector/event_feed_test.go
@@ -1,0 +1,656 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
+	"github.com/conductorone/baton-servicenow/pkg/servicenow"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// ctxWithObservedLogs returns a context carrying an observed zap logger and the
+// observed-logs sink, so tests can assert on what the feed logged.
+func ctxWithObservedLogs(t *testing.T) (context.Context, *observer.ObservedLogs) {
+	t.Helper()
+	core, logs := observer.New(zapcore.DebugLevel)
+	ctx := ctxzap.ToContext(t.Context(), zap.New(core))
+	return ctx, logs
+}
+
+// drainFeed walks ListEvents to completion (HasMore=false), returning every
+// event collected across the paged calls. It guards against an infinite loop.
+func drainFeed(t *testing.T, ctx context.Context, f *serviceNowEventFeed) []*v2.Event {
+	t.Helper()
+	var all []*v2.Event
+	tok := &pagination.StreamToken{Size: 100}
+	for i := 0; i < 100; i++ {
+		evs, state, _, err := f.ListEvents(ctx, nil, tok)
+		if err != nil {
+			t.Fatalf("ListEvents returned error: %v", err)
+		}
+		all = append(all, evs...)
+		if state == nil || !state.HasMore {
+			return all
+		}
+		tok = &pagination.StreamToken{Size: 100, Cursor: state.Cursor}
+	}
+	t.Fatal("drainFeed did not terminate")
+	return nil
+}
+
+// emptyFetchersFeed builds a feed whose every phase returns no rows and no
+// error, so tests can override only the phases they exercise.
+func emptyFetchersFeed() *serviceNowEventFeed {
+	return &serviceNowEventFeed{
+		fetchGroupMembers: func(context.Context, string, servicenow.PaginationVars) ([]servicenow.GroupMember, string, error) {
+			return nil, "", nil
+		},
+		fetchUserRoles: func(context.Context, string, servicenow.PaginationVars) ([]servicenow.UserToRole, string, error) {
+			return nil, "", nil
+		},
+		fetchGroupRoles: func(context.Context, string, servicenow.PaginationVars) ([]servicenow.GroupToRole, string, error) {
+			return nil, "", nil
+		},
+		fetchUsersChanged: func(context.Context, string, servicenow.PaginationVars) ([]servicenow.User, string, error) {
+			return nil, "", nil
+		},
+		fetchJoinDeletes: func(context.Context, []string, string, servicenow.PaginationVars) ([]servicenow.AuditDeleteRecord, string, error) {
+			return nil, "", nil
+		},
+		fetchAudit: func(context.Context, []string, string, servicenow.PaginationVars) ([]servicenow.AuditRecord, string, error) {
+			return nil, "", nil
+		},
+		fetchAuditDeletedTables: func(context.Context) ([]string, error) {
+			// Default: all three grant join tables captured to sys_audit_delete (no
+			// revoke warning) unless a test overrides it.
+			return []string{
+				servicenow.TableUserGroupMember,
+				servicenow.TableUserHasRole,
+				servicenow.TableGroupHasRole,
+			}, nil
+		},
+	}
+}
+
+func TestGroupMemberCreateGrantEvent(t *testing.T) {
+	m := &servicenow.GroupMember{
+		BaseResource: servicenow.BaseResource{Id: "join1"},
+		User:         "user1",
+		Group:        "group1",
+		SysCreatedOn: "2026-06-18 10:00:00",
+	}
+	ev := groupMemberCreateGrantEvent(m)
+
+	if ev.GetId() != "grmember:join1" {
+		t.Fatalf("unexpected event id: %s", ev.GetId())
+	}
+	cg := ev.GetCreateGrantEvent()
+	if cg == nil {
+		t.Fatal("expected CreateGrantEvent")
+	}
+	if got := cg.GetPrincipal().GetId(); got.GetResourceType() != resourceTypeUser.Id || got.GetResource() != "user1" {
+		t.Fatalf("unexpected principal: %v", got)
+	}
+	entRes := cg.GetEntitlement().GetResource().GetId()
+	if entRes.GetResourceType() != resourceTypeGroup.Id || entRes.GetResource() != "group1" {
+		t.Fatalf("unexpected entitlement resource: %v", entRes)
+	}
+	if cg.GetEntitlement().GetSlug() != groupMembership {
+		t.Fatalf("unexpected entitlement slug: %s", cg.GetEntitlement().GetSlug())
+	}
+	if ev.GetOccurredAt().AsTime().Format(snDatetimeLayout) != "2026-06-18 10:00:00" {
+		t.Fatalf("unexpected occurred_at: %s", ev.GetOccurredAt().AsTime())
+	}
+}
+
+func TestUserRoleCreateGrantEvent(t *testing.T) {
+	r := &servicenow.UserToRole{
+		BaseResource: servicenow.BaseResource{Id: "ur1"},
+		User:         "user2",
+		Role:         "role2",
+		SysCreatedOn: "2026-06-18 11:30:00",
+	}
+	ev := userRoleCreateGrantEvent(r)
+	cg := ev.GetCreateGrantEvent()
+	if cg == nil {
+		t.Fatal("expected CreateGrantEvent")
+	}
+	if cg.GetPrincipal().GetId().GetResource() != "user2" {
+		t.Fatalf("unexpected principal: %v", cg.GetPrincipal().GetId())
+	}
+	er := cg.GetEntitlement().GetResource().GetId()
+	if er.GetResourceType() != resourceTypeRole.Id || er.GetResource() != "role2" {
+		t.Fatalf("unexpected entitlement resource: %v", er)
+	}
+	if cg.GetEntitlement().GetSlug() != roleMembership {
+		t.Fatalf("unexpected slug: %s", cg.GetEntitlement().GetSlug())
+	}
+}
+
+func TestGroupRoleCreateGrantEvent(t *testing.T) {
+	r := &servicenow.GroupToRole{
+		BaseResource: servicenow.BaseResource{Id: "gr1"},
+		Group:        "group3",
+		Role:         "role3",
+		SysCreatedOn: "2026-06-18 12:00:00",
+	}
+	ev := groupRoleCreateGrantEvent(r)
+	cg := ev.GetCreateGrantEvent()
+	if cg == nil {
+		t.Fatal("expected CreateGrantEvent")
+	}
+	if p := cg.GetPrincipal().GetId(); p.GetResourceType() != resourceTypeGroup.Id || p.GetResource() != "group3" {
+		t.Fatalf("unexpected principal: %v", p)
+	}
+	if er := cg.GetEntitlement().GetResource().GetId(); er.GetResource() != "role3" {
+		t.Fatalf("unexpected entitlement resource: %v", er)
+	}
+}
+
+func TestAuditChangeEvent_UserChange(t *testing.T) {
+	a := &servicenow.AuditRecord{
+		SysID:        "aud1",
+		Tablename:    servicenow.TableUser,
+		DocumentKey:  "user5",
+		Fieldname:    "active",
+		OldValue:     "true",
+		NewValue:     "false",
+		SysCreatedOn: "2026-06-18 14:00:00",
+	}
+	ev := auditChangeEvent(a)
+	if ev == nil {
+		t.Fatal("expected an event for a sys_user change")
+	}
+	if ev.GetId() != "audit:aud1" {
+		t.Fatalf("unexpected id: %s", ev.GetId())
+	}
+	rc := ev.GetResourceChangeEvent()
+	if rc == nil {
+		t.Fatal("expected ResourceChangeEvent")
+	}
+	if rc.GetResourceId().GetResourceType() != resourceTypeUser.Id || rc.GetResourceId().GetResource() != "user5" {
+		t.Fatalf("unexpected resource id: %v", rc.GetResourceId())
+	}
+}
+
+func TestAuditChangeEvent_NonUserSkipped(t *testing.T) {
+	// A delete on a join table is not resolvable to a grant; skip it here.
+	a := &servicenow.AuditRecord{
+		SysID:        "aud2",
+		Tablename:    servicenow.TableUserGroupMember,
+		DocumentKey:  "joinrow",
+		Fieldname:    "DELETED",
+		SysCreatedOn: "2026-06-18 15:00:00",
+	}
+	if ev := auditChangeEvent(a); ev != nil {
+		t.Fatalf("expected nil event for join-table audit row, got %v", ev)
+	}
+}
+
+// Real sys_audit_delete.payload XML samples verified on dev289997. Each
+// reference field is an element whose TEXT is the referenced sys_id (with a
+// display_value attribute we ignore).
+const (
+	grmemberDeletePayload = `<sys_user_grmember><group display_value="G">5338c33d83290f5442cb56d6feaad3d9</group>` +
+		`<user display_value="U">0738c33d83290f5442cb56d6feaad3d1</user></sys_user_grmember>`
+
+	userHasRoleDeletePayload = `<sys_user_has_role><role display_value="admin">role0001role0001role0001role00010</role>` +
+		`<user display_value="U">0738c33d83290f5442cb56d6feaad3d1</user></sys_user_has_role>`
+
+	groupHasRoleDeletePayload = `<sys_group_has_role><group display_value="G">5338c33d83290f5442cb56d6feaad3d9</group>` +
+		`<role display_value="admin">role0001role0001role0001role00010</role></sys_group_has_role>`
+)
+
+func TestJoinDeleteRevokeEvent_GroupMember(t *testing.T) {
+	d := &servicenow.AuditDeleteRecord{
+		Tablename:    servicenow.TableUserGroupMember,
+		DocumentKey:  "join1",
+		SysCreatedOn: "2026-06-18 16:00:00",
+		Payload:      grmemberDeletePayload,
+	}
+	ev := joinDeleteRevokeEvent(context.Background(), d)
+	if ev == nil {
+		t.Fatal("expected a revoke event")
+	}
+	if ev.GetId() != "revoke:join1" {
+		t.Fatalf("unexpected id: %s", ev.GetId())
+	}
+	rv := ev.GetCreateRevokeEvent()
+	if rv == nil {
+		t.Fatal("expected CreateRevokeEvent")
+	}
+	if p := rv.GetPrincipal().GetId(); p.GetResourceType() != resourceTypeUser.Id || p.GetResource() != "0738c33d83290f5442cb56d6feaad3d1" {
+		t.Fatalf("unexpected principal: %v", p)
+	}
+	er := rv.GetEntitlement().GetResource().GetId()
+	if er.GetResourceType() != resourceTypeGroup.Id || er.GetResource() != "5338c33d83290f5442cb56d6feaad3d9" {
+		t.Fatalf("unexpected entitlement resource: %v", er)
+	}
+	if rv.GetEntitlement().GetSlug() != groupMembership {
+		t.Fatalf("unexpected slug: %s", rv.GetEntitlement().GetSlug())
+	}
+	if ev.GetOccurredAt().AsTime().Format(snDatetimeLayout) != "2026-06-18 16:00:00" {
+		t.Fatalf("unexpected occurred_at: %s", ev.GetOccurredAt().AsTime())
+	}
+}
+
+func TestJoinDeleteRevokeEvent_UserHasRole(t *testing.T) {
+	d := &servicenow.AuditDeleteRecord{
+		Tablename:   servicenow.TableUserHasRole,
+		DocumentKey: "join2",
+		Payload:     userHasRoleDeletePayload,
+	}
+	ev := joinDeleteRevokeEvent(context.Background(), d)
+	if ev == nil {
+		t.Fatal("expected a revoke event")
+	}
+	rv := ev.GetCreateRevokeEvent()
+	if p := rv.GetPrincipal().GetId(); p.GetResourceType() != resourceTypeUser.Id || p.GetResource() != "0738c33d83290f5442cb56d6feaad3d1" {
+		t.Fatalf("unexpected principal: %v", p)
+	}
+	er := rv.GetEntitlement().GetResource().GetId()
+	if er.GetResourceType() != resourceTypeRole.Id || er.GetResource() != "role0001role0001role0001role00010" {
+		t.Fatalf("unexpected entitlement resource: %v", er)
+	}
+	if rv.GetEntitlement().GetSlug() != roleMembership {
+		t.Fatalf("unexpected slug: %s", rv.GetEntitlement().GetSlug())
+	}
+}
+
+func TestJoinDeleteRevokeEvent_GroupHasRole(t *testing.T) {
+	d := &servicenow.AuditDeleteRecord{
+		Tablename:   servicenow.TableGroupHasRole,
+		DocumentKey: "join3",
+		Payload:     groupHasRoleDeletePayload,
+	}
+	ev := joinDeleteRevokeEvent(context.Background(), d)
+	if ev == nil {
+		t.Fatal("expected a revoke event")
+	}
+	rv := ev.GetCreateRevokeEvent()
+	// Group is the principal for sys_group_has_role.
+	if p := rv.GetPrincipal().GetId(); p.GetResourceType() != resourceTypeGroup.Id || p.GetResource() != "5338c33d83290f5442cb56d6feaad3d9" {
+		t.Fatalf("unexpected principal: %v", p)
+	}
+	er := rv.GetEntitlement().GetResource().GetId()
+	if er.GetResourceType() != resourceTypeRole.Id || er.GetResource() != "role0001role0001role0001role00010" {
+		t.Fatalf("unexpected entitlement resource: %v", er)
+	}
+	if rv.GetEntitlement().GetSlug() != roleMembership {
+		t.Fatalf("unexpected slug: %s", rv.GetEntitlement().GetSlug())
+	}
+}
+
+func TestJoinDeleteRevokeEvent_EmptyPayloadSkipped(t *testing.T) {
+	d := &servicenow.AuditDeleteRecord{
+		Tablename:   servicenow.TableUserGroupMember,
+		DocumentKey: "join5",
+		Payload:     "",
+	}
+	if ev := joinDeleteRevokeEvent(context.Background(), d); ev != nil {
+		t.Fatalf("expected nil for empty payload, got %v", ev)
+	}
+}
+
+func TestJoinDeleteRevokeEvent_UnparseablePayloadSkipped(t *testing.T) {
+	d := &servicenow.AuditDeleteRecord{
+		Tablename:   servicenow.TableUserGroupMember,
+		DocumentKey: "join6",
+		Payload:     "<not-valid-xml<<<",
+	}
+	if ev := joinDeleteRevokeEvent(context.Background(), d); ev != nil {
+		t.Fatalf("expected nil for unparseable payload, got %v", ev)
+	}
+}
+
+func TestJoinDeleteRevokeEvent_IncompletePayloadSkipped(t *testing.T) {
+	// Payload parses but is missing a reference field.
+	d := &servicenow.AuditDeleteRecord{
+		Tablename:   servicenow.TableUserGroupMember,
+		DocumentKey: "join7",
+		Payload:     `<sys_user_grmember><user>u1</user></sys_user_grmember>`,
+	}
+	if ev := joinDeleteRevokeEvent(context.Background(), d); ev != nil {
+		t.Fatalf("expected nil for incomplete payload, got %v", ev)
+	}
+}
+
+func TestJoinDeleteRevokeEvent_UnknownTableSkipped(t *testing.T) {
+	d := &servicenow.AuditDeleteRecord{
+		Tablename:   servicenow.TableUser,
+		DocumentKey: "u1",
+		Payload:     `<sys_user><user_name>jdoe</user_name></sys_user>`,
+	}
+	if ev := joinDeleteRevokeEvent(context.Background(), d); ev != nil {
+		t.Fatalf("expected nil for non-join table, got %v", ev)
+	}
+}
+
+func TestOccurredAt_FallbackOnUnparseable(t *testing.T) {
+	ts := occurredAt("not-a-date")
+	if ts == nil || ts.AsTime().IsZero() {
+		t.Fatal("expected a non-zero fallback timestamp")
+	}
+}
+
+func TestFeedCursor_RoundTrip(t *testing.T) {
+	c := feedCursor{Phase: phaseUserRoles, Offset: 200}
+	enc, err := c.encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := parseFeedCursor(enc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != c {
+		t.Fatalf("round trip mismatch: %+v != %+v", got, c)
+	}
+
+	// Empty cursor starts at the first phase, offset 0.
+	zero, err := parseFeedCursor("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if zero.Phase != phaseGroupMembers || zero.Offset != 0 {
+		t.Fatalf("unexpected zero cursor: %+v", zero)
+	}
+}
+
+func TestUserChangeEvent(t *testing.T) {
+	u := &servicenow.User{
+		BaseResource: servicenow.BaseResource{Id: "user42"},
+		SysUpdatedOn: "2026-06-19 07:14:22",
+	}
+	ev := userChangeEvent(u)
+
+	if ev.GetId() != "userchange:user42" {
+		t.Fatalf("unexpected event id: %s", ev.GetId())
+	}
+	rc := ev.GetResourceChangeEvent()
+	if rc == nil {
+		t.Fatal("expected ResourceChangeEvent")
+	}
+	if got := rc.GetResourceId(); got.GetResourceType() != resourceTypeUser.Id || got.GetResource() != "user42" {
+		t.Fatalf("unexpected resource id: %v", got)
+	}
+	if ev.GetOccurredAt().AsTime().Format(snDatetimeLayout) != "2026-06-19 07:14:22" {
+		t.Fatalf("unexpected occurred_at: %s", ev.GetOccurredAt().AsTime())
+	}
+}
+
+// TestListEvents_UserChangePhase verifies the audit-INDEPENDENT account-change
+// phase: polling sys_user by sys_updated_on surfaces both a newly created account
+// and a disabled (active=false) account as RESOURCE_CHANGE events, with no
+// sys_audit dependency.
+func TestListEvents_UserChangePhase(t *testing.T) {
+	ctx, _ := ctxWithObservedLogs(t)
+
+	f := emptyFetchersFeed()
+	f.fetchUsersChanged = func(context.Context, string, servicenow.PaginationVars) ([]servicenow.User, string, error) {
+		return []servicenow.User{
+			{BaseResource: servicenow.BaseResource{Id: "newuser1"}, Active: "true", SysUpdatedOn: "2026-06-19 07:14:22"},   // created
+			{BaseResource: servicenow.BaseResource{Id: "disabled1"}, Active: "false", SysUpdatedOn: "2026-06-19 07:30:37"}, // disabled
+		}, "", nil
+	}
+
+	events := drainFeed(t, ctx, f)
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 resource-change events, got %d", len(events))
+	}
+	ids := map[string]bool{}
+	for _, ev := range events {
+		rc := ev.GetResourceChangeEvent()
+		if rc == nil {
+			t.Fatalf("expected ResourceChangeEvent, got %+v", ev)
+		}
+		if rc.GetResourceId().GetResourceType() != resourceTypeUser.Id {
+			t.Fatalf("unexpected resource type: %v", rc.GetResourceId())
+		}
+		ids[rc.GetResourceId().GetResource()] = true
+	}
+	if !ids["newuser1"] || !ids["disabled1"] {
+		t.Fatalf("expected both created and disabled accounts, got %v", ids)
+	}
+}
+
+// --- Change A: phase isolation (resilience) ---
+
+// TestListEvents_AuditPhaseErrorIsolated verifies that a HARD error from BOTH
+// audit-backed phases (sys_audit_delete revokes and sys_audit account changes)
+// is logged-and-skipped rather than fatal: the grant-create phases still return
+// their events, the walk completes (cursor reaches phaseDone), and no grant-
+// create events are lost.
+func TestListEvents_AuditPhaseErrorIsolated(t *testing.T) {
+	ctx, logs := ctxWithObservedLogs(t)
+
+	f := emptyFetchersFeed()
+	// One grant-create event from the very first phase.
+	f.fetchGroupMembers = func(context.Context, string, servicenow.PaginationVars) ([]servicenow.GroupMember, string, error) {
+		return []servicenow.GroupMember{
+			{BaseResource: servicenow.BaseResource{Id: "join1"}, User: "u1", Group: "g1", SysCreatedOn: "2026-06-18 10:00:00"},
+		}, "", nil
+	}
+	// Both audit-backed phases hard-error (e.g. ACL/permission denial).
+	auditErr := errors.New("403 ACL Exception: read on sys_audit_delete denied")
+	f.fetchJoinDeletes = func(context.Context, []string, string, servicenow.PaginationVars) ([]servicenow.AuditDeleteRecord, string, error) {
+		return nil, "", auditErr
+	}
+	f.fetchAudit = func(context.Context, []string, string, servicenow.PaginationVars) ([]servicenow.AuditRecord, string, error) {
+		return nil, "", auditErr
+	}
+
+	events := drainFeed(t, ctx, f)
+
+	// The grant-create event survives the audit-phase failures.
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 grant-create event, got %d", len(events))
+	}
+	if events[0].GetId() != "grmember:join1" || events[0].GetCreateGrantEvent() == nil {
+		t.Fatalf("unexpected surviving event: %+v", events[0])
+	}
+
+	// Each skipped audit-backed phase logged a warning (2 phases -> 2 warns).
+	warns := logs.FilterLevelExact(zapcore.WarnLevel).
+		FilterMessageSnippet("skipping audit-backed event-feed phase").All()
+	if len(warns) != 2 {
+		t.Fatalf("expected 2 skipped-phase warnings, got %d: %+v", len(warns), warns)
+	}
+}
+
+// TestListEvents_GrantCreateErrorPropagates verifies that an error on a
+// grant-CREATE phase (the real, audit-independent data source) is NOT swallowed:
+// it propagates out of ListEvents.
+func TestListEvents_GrantCreateErrorPropagates(t *testing.T) {
+	ctx, _ := ctxWithObservedLogs(t)
+
+	f := emptyFetchersFeed()
+	boom := errors.New("network is down")
+	f.fetchUserRoles = func(context.Context, string, servicenow.PaginationVars) ([]servicenow.UserToRole, string, error) {
+		return nil, "", boom
+	}
+
+	tok := &pagination.StreamToken{Size: 100}
+	for i := 0; i < 100; i++ {
+		_, state, _, err := f.ListEvents(ctx, nil, tok)
+		if err != nil {
+			if !strings.Contains(err.Error(), "network is down") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			return // propagated, as required
+		}
+		if state == nil || !state.HasMore {
+			t.Fatal("expected grant-create phase error to propagate, but the walk completed cleanly")
+		}
+		tok = &pagination.StreamToken{Size: 100, Cursor: state.Cursor}
+	}
+	t.Fatal("did not terminate")
+}
+
+// TestListEvents_SkippedPhaseCursorAdvances verifies the cursor advances exactly
+// one phase past a skipped audit phase (no stall, no re-loop, no dropped later
+// phase): with phaseJoinDeletes failing, the subsequent phaseAudit still runs
+// and its event is returned.
+func TestListEvents_SkippedPhaseCursorAdvances(t *testing.T) {
+	ctx, _ := ctxWithObservedLogs(t)
+
+	f := emptyFetchersFeed()
+	// Revoke phase errors; audit phase (the NEXT phase) succeeds with one event.
+	f.fetchJoinDeletes = func(context.Context, []string, string, servicenow.PaginationVars) ([]servicenow.AuditDeleteRecord, string, error) {
+		return nil, "", errors.New("sys_audit_delete locked down")
+	}
+	f.fetchAudit = func(context.Context, []string, string, servicenow.PaginationVars) ([]servicenow.AuditRecord, string, error) {
+		return []servicenow.AuditRecord{
+			{SysID: "a1", Tablename: servicenow.TableUser, DocumentKey: "user9", Fieldname: "DELETED", SysCreatedOn: "2026-06-18 11:00:00"},
+		}, "", nil
+	}
+
+	events := drainFeed(t, ctx, f)
+	if len(events) != 1 || events[0].GetResourceChangeEvent() == nil {
+		t.Fatalf("expected the post-skip phaseAudit event to survive; got %d events: %+v", len(events), events)
+	}
+	if got := events[0].GetResourceChangeEvent().GetResourceId().GetResource(); got != "user9" {
+		t.Fatalf("unexpected resource-change id: %s", got)
+	}
+}
+
+// --- Change B: audit-config preflight warnings ---
+
+// --- Check 1: revoke detection (glide.ui.audit_deleted_tables) ---
+
+// joinTablesPresent is the real dev289997 property value (the three grant join
+// tables ARE present, so no revoke warning should fire).
+func joinTablesPresent() []string {
+	return []string{
+		servicenow.TableUserGroupMember,
+		servicenow.TableUserHasRole,
+		servicenow.TableGroupHasRole,
+		// Other tables ServiceNow lists.
+		"sys_user",
+		"sys_user_group",
+		"sys_user_role",
+	}
+}
+
+func TestRevokeDetectionPreflight_JoinTablesPresent_NoWarn(t *testing.T) {
+	ctx, logs := ctxWithObservedLogs(t)
+
+	f := emptyFetchersFeed()
+	f.fetchAuditDeletedTables = func(context.Context) ([]string, error) {
+		return joinTablesPresent(), nil
+	}
+
+	f.revokeDetectionPreflight(ctx)
+
+	if n := logs.FilterLevelExact(zapcore.WarnLevel).Len(); n != 0 {
+		t.Fatalf("expected no revoke warning when all join tables are captured, got %d", n)
+	}
+}
+
+func TestRevokeDetectionPreflight_JoinTableMissing_Warns(t *testing.T) {
+	ctx, logs := ctxWithObservedLogs(t)
+
+	f := emptyFetchersFeed()
+	f.fetchAuditDeletedTables = func(context.Context) ([]string, error) {
+		// sys_group_has_role missing from the captured list.
+		return []string{
+			servicenow.TableUserGroupMember,
+			servicenow.TableUserHasRole,
+		}, nil
+	}
+
+	f.revokeDetectionPreflight(ctx)
+
+	warns := logs.FilterLevelExact(zapcore.WarnLevel).
+		FilterMessageSnippet("delete-capture is NOT enabled").All()
+	if len(warns) != 1 {
+		t.Fatalf("expected 1 revoke warning for the missing join table, got %d", len(warns))
+	}
+	found := false
+	for _, fld := range warns[0].Context {
+		if fld.Key == "uncaptured_tables" {
+			found = true
+			// zap.Strings renders as a zapcore.ArrayMarshaler; check via its
+			// encoded form rather than a concrete []string cast.
+			if got := fmt.Sprint(fld.Interface); !strings.Contains(got, servicenow.TableGroupHasRole) {
+				t.Fatalf("expected uncaptured_tables to name %s, got %q", servicenow.TableGroupHasRole, got)
+			}
+			if strings.Contains(fmt.Sprint(fld.Interface), servicenow.TableUserGroupMember) {
+				t.Fatalf("captured table %s should not be in uncaptured_tables", servicenow.TableUserGroupMember)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("warning did not name the uncaptured table(s): %+v", warns[0].Context)
+	}
+}
+
+func TestRevokeDetectionPreflight_CheckFailureSwallowed(t *testing.T) {
+	ctx, logs := ctxWithObservedLogs(t)
+
+	f := emptyFetchersFeed()
+	f.fetchAuditDeletedTables = func(context.Context) ([]string, error) {
+		return nil, errors.New("sys_properties unreadable")
+	}
+
+	f.revokeDetectionPreflight(ctx)
+
+	if n := logs.FilterLevelExact(zapcore.WarnLevel).Len(); n != 0 {
+		t.Fatalf("a failed revoke-detection check must not warn, got %d warnings", n)
+	}
+}
+
+func TestAuditConfigPreflight_RunsOnce(t *testing.T) {
+	ctx, logs := ctxWithObservedLogs(t)
+
+	calls := 0
+	f := emptyFetchersFeed()
+	f.fetchAuditDeletedTables = func(context.Context) ([]string, error) {
+		calls++
+		// Omit a grant join table so the single advisory check warns once.
+		return []string{servicenow.TableUserHasRole, servicenow.TableGroupHasRole}, nil
+	}
+
+	f.auditConfigPreflight(ctx)
+	f.auditConfigPreflight(ctx)
+	f.auditConfigPreflight(ctx)
+
+	if calls != 1 {
+		t.Fatalf("expected preflight to run exactly once, ran %d times", calls)
+	}
+	if n := logs.FilterLevelExact(zapcore.WarnLevel).Len(); n != 1 {
+		t.Fatalf("expected exactly 1 warning across repeated calls, got %d", n)
+	}
+}
+
+func TestEventFeedMetadata(t *testing.T) {
+	f := &serviceNowEventFeed{}
+	md := f.EventFeedMetadata(t.Context())
+	if md.GetId() != servicenowEventFeedID {
+		t.Fatalf("unexpected feed id: %s", md.GetId())
+	}
+	want := map[v2.EventType]bool{
+		v2.EventType_EVENT_TYPE_CREATE_GRANT:    false,
+		v2.EventType_EVENT_TYPE_CREATE_REVOKE:   false,
+		v2.EventType_EVENT_TYPE_RESOURCE_CHANGE: false,
+	}
+	for _, et := range md.GetSupportedEventTypes() {
+		if _, ok := want[et]; ok {
+			want[et] = true
+		}
+	}
+	for et, seen := range want {
+		if !seen {
+			t.Fatalf("missing supported event type: %v", et)
+		}
+	}
+}

--- a/pkg/connector/event_feed_test.go
+++ b/pkg/connector/event_feed_test.go
@@ -594,7 +594,7 @@ func TestRevokeDetectionPreflight_JoinTableMissing_Warns(t *testing.T) {
 	}
 }
 
-func TestRevokeDetectionPreflight_CheckFailureSwallowed(t *testing.T) {
+func TestRevokeDetectionPreflight_CheckFailureWarns(t *testing.T) {
 	ctx, logs := ctxWithObservedLogs(t)
 
 	f := emptyFetchersFeed()
@@ -602,10 +602,12 @@ func TestRevokeDetectionPreflight_CheckFailureSwallowed(t *testing.T) {
 		return nil, errors.New("sys_properties unreadable")
 	}
 
+	// A failed check must not fail the sync, but it must warn so the operator
+	// is not left blind to unverified revoke capture.
 	f.revokeDetectionPreflight(ctx)
 
-	if n := logs.FilterLevelExact(zapcore.WarnLevel).Len(); n != 0 {
-		t.Fatalf("a failed revoke-detection check must not warn, got %d warnings", n)
+	if n := logs.FilterLevelExact(zapcore.WarnLevel).Len(); n != 1 {
+		t.Fatalf("a failed revoke-detection check must warn exactly once, got %d warnings", n)
 	}
 }
 

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -34,14 +34,10 @@ const (
 	GroupMembersBaseUrl      = TableAPIBaseURL + "/sys_user_grmember"
 	GroupMemberDetailBaseUrl = GroupMembersBaseUrl + "/%s"
 
-	// AuditDeleteBaseUrl is the sys_audit_delete table: one row per hard delete
-	// of an audited record. The event feed reads it to emit grant-revoke events.
+	// sys_audit_delete: one row per hard delete (event-feed revoke source).
 	AuditDeleteBaseUrl = TableAPIBaseURL + "/sys_audit_delete"
 
-	// AuditBaseUrl is the sys_audit table: one row per field-level change of an
-	// audited record (tablename/documentkey/fieldname/oldvalue/newvalue). The
-	// event feed reads it to surface account changes (sys_user) and audited
-	// deletes (fieldname=="DELETED") on the access tables in near real time.
+	// sys_audit: one row per field change / audited delete (event-feed source).
 	AuditBaseUrl = TableAPIBaseURL + "/sys_audit"
 
 	RolesBaseUrl           = TableAPIBaseURL + "/sys_user_role"
@@ -80,21 +76,13 @@ const (
 
 	InstanceURLTemplate = `{{.Deployment}}.service-now.com`
 
-	// DictionaryBaseUrl is the sys_dictionary table: the data dictionary. Each row
-	// describes a table (when its `element` is empty — the table-level collection
-	// record) or a column. Its `audit` flag is the connector-readable signal for
-	// whether field-change auditing is enabled (drives sys_audit), used by the
-	// event-feed audit-config preflight.
+	// sys_dictionary: data dictionary; table-level `audit` flag drives sys_audit.
 	DictionaryBaseUrl = TableAPIBaseURL + "/sys_dictionary"
 
-	// PropertyBaseUrl is the sys_properties table (system properties). The
-	// event-feed revoke-detection preflight reads the glide.ui.audit_deleted_tables
-	// row from it: the comma-separated list of tables whose hard deletes are
-	// captured to sys_audit_delete (the grant-REVOKE source).
+	// sys_properties: system properties (read for glide.ui.audit_deleted_tables).
 	PropertyBaseUrl = TableAPIBaseURL + "/sys_properties"
 
-	// AuditDeletedTablesProperty is the sys_properties name whose value lists the
-	// tables whose deletes are recorded in sys_audit_delete.
+	// AuditDeletedTablesProperty lists tables whose deletes go to sys_audit_delete.
 	AuditDeletedTablesProperty = "glide.ui.audit_deleted_tables"
 
 	// Variable sets & variables (Table API).
@@ -190,24 +178,13 @@ func (c *Client) GetBaseURL() string {
 	return c.baseURL
 }
 
-// AuditDeletePayloadFields is the field set fetched from sys_audit_delete for
-// the event feed. It adds `payload` (the full XML dump of the deleted row) on
-// top of AuditDeleteFields so the feed can resolve a deleted join row back to
-// its (principal, target) pair and emit a revoke event.
+// AuditDeletePayloadFields adds `payload` (the deleted row's XML) to
+// AuditDeleteFields so the feed can resolve a deleted join row to a revoke.
 var AuditDeletePayloadFields = []string{"tablename", fieldDocumentKey, "sys_created_on", "payload"}
 
-// GetDeletedSincePayload lists sys_audit_delete rows for one or more tables
-// whose delete was logged at or after createdSince ("YYYY-MM-DD HH:MM:SS",
-// UTC), INCLUDING the `payload` column and ordered by sys_created_on ascending
-// so the event feed advances its cursor monotonically. An empty createdSince
-// fetches from the beginning of the delete history. The returned next-page
-// token is the Table API offset for the following page ("" when exhausted).
-//
-// This is the event-feed delete source (it mirrors GetAuditSince's ordering and
-// GetDeletedSince's filtering, but additionally fetches the payload so deletes
-// of join rows become resolvable revoke events). Errors are surfaced to the
-// caller; the feed degrades gracefully and the periodic full sync remains the
-// source of truth.
+// GetDeletedSincePayload lists sys_audit_delete rows (with payload) for the given
+// tables at/after createdSince, ordered by sys_created_on ascending; this is the
+// event feed's revoke source. Empty createdSince fetches from the start.
 func (c *Client) GetDeletedSincePayload(ctx context.Context, tableNames []string, createdSince string, paginationVars PaginationVars) ([]AuditDeleteRecord, string, error) {
 	var resp AuditDeleteResponse
 
@@ -246,8 +223,7 @@ func (c *Client) GetDeletedSincePayload(ctx context.Context, tableNames []string
 	return resp.Result, nextPage, nil
 }
 
-// fieldSysID/fieldUser are ServiceNow columns requested in the sysparm_fields
-// of the event-feed list calls.
+// Column names requested in the event-feed list calls.
 const (
 	fieldSysID       = "sys_id"
 	fieldUser        = "user"
@@ -257,16 +233,8 @@ const (
 // AuditFields is the field set fetched from sys_audit for the event feed.
 var AuditFields = []string{fieldSysID, "tablename", fieldDocumentKey, "fieldname", "oldvalue", "newvalue", "sys_created_on", fieldUser}
 
-// GetAuditSince lists sys_audit rows for one or more tables whose change was
-// logged at or after createdSince ("YYYY-MM-DD HH:MM:SS", UTC), ordered by
-// sys_created_on ascending so the event feed advances its cursor monotonically.
-// An empty createdSince fetches from the beginning of the audit history. The
-// returned next-page token is the Table API offset for the following page (""
-// when exhausted).
-//
-// Note: an error here (e.g. auditing disabled, or the caller lacks read access
-// to sys_audit) is surfaced to the caller; the event feed degrades gracefully
-// and the periodic full sync remains the source of truth.
+// GetAuditSince lists sys_audit rows for the given tables at/after createdSince,
+// ordered by sys_created_on ascending. Empty createdSince fetches from the start.
 func (c *Client) GetAuditSince(ctx context.Context, tableNames []string, createdSince string, paginationVars PaginationVars) ([]AuditRecord, string, error) {
 	var resp AuditResponse
 
@@ -305,17 +273,9 @@ func (c *Client) GetAuditSince(ctx context.Context, tableNames []string, created
 	return resp.Result, nextPage, nil
 }
 
-// GetTableAuditFlags reports, for each of the given table names, whether
-// field-change auditing is enabled on that table. It reads the table-level
-// collection record from sys_dictionary (the row where `element` is empty) and
-// returns a map tableName -> auditEnabled.
-//
-// The flag reflects sys_dictionary's `audit` column ("true"/"false"); a table
-// absent from the result (no table-level record returned, or unreadable) is
-// reported as false. This signals whether sys_audit field-change rows will be
-// produced — it does NOT reflect delete-recovery (sys_audit_delete), which is a
-// separate, independently-configured capability. Callers must treat this as
-// advisory only.
+// GetTableAuditFlags returns tableName -> field-change-auditing-enabled, read
+// from each table's sys_dictionary collection record (advisory only; a table
+// absent from the result is reported false).
 func (c *Client) GetTableAuditFlags(ctx context.Context, tableNames []string) (map[string]bool, error) {
 	out := make(map[string]bool, len(tableNames))
 	if len(tableNames) == 0 {
@@ -323,8 +283,7 @@ func (c *Client) GetTableAuditFlags(ctx context.Context, tableNames []string) (m
 	}
 
 	var resp DictionaryResponse
-	// Only the table-level record carries the table's audit flag: name IN (...)
-	// AND element is empty.
+	// Only the table-level record (element empty) carries the table's audit flag.
 	query := "nameIN" + strings.Join(tableNames, ",") + "^elementISEMPTY"
 	reqOpts := []ReqOpt{
 		WithQuery(query),
@@ -348,21 +307,10 @@ func (c *Client) GetTableAuditFlags(ctx context.Context, tableNames []string) (m
 	return out, nil
 }
 
-// GetAuditDeletedTables reads the glide.ui.audit_deleted_tables system property
-// (sys_properties) and returns the list of table names whose hard deletes are
-// captured to sys_audit_delete. That capture is the source of near-real-time
-// grant-REVOKE events, so a join table's PRESENCE in this list means its revokes
-// are reliably captured.
-//
-// Caveat (do NOT treat absence as definitive): some tables can have their
-// deletes captured to sys_audit_delete by their own mechanism without appearing
-// in this property. So presence => reliably captured; absence => not reliably
-// captured via this property (but may still be captured by other means).
-// Callers must treat this as advisory only.
-//
-// An empty / unset property yields an empty list (no error). Errors (e.g. lack
-// of read access to sys_properties) are surfaced to the caller, which degrades
-// gracefully.
+// GetAuditDeletedTables returns the tables listed in glide.ui.audit_deleted_tables
+// (those whose deletes are captured to sys_audit_delete, the revoke source).
+// Advisory: presence => reliably captured; absence is not definitive (some tables
+// capture deletes by other means). Unset property yields an empty list, no error.
 func (c *Client) GetAuditDeletedTables(ctx context.Context) ([]string, error) {
 	var resp PropertyResponse
 	reqOpts := []ReqOpt{

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -76,9 +76,6 @@ const (
 
 	InstanceURLTemplate = `{{.Deployment}}.service-now.com`
 
-	// sys_dictionary: data dictionary; table-level `audit` flag drives sys_audit.
-	DictionaryBaseUrl = TableAPIBaseURL + "/sys_dictionary"
-
 	// sys_properties: system properties (read for glide.ui.audit_deleted_tables).
 	PropertyBaseUrl = TableAPIBaseURL + "/sys_properties"
 
@@ -271,40 +268,6 @@ func (c *Client) GetAuditSince(ctx context.Context, tableNames []string, created
 		return nil, "", err
 	}
 	return resp.Result, nextPage, nil
-}
-
-// GetTableAuditFlags returns tableName -> field-change-auditing-enabled, read
-// from each table's sys_dictionary collection record (advisory only; a table
-// absent from the result is reported false).
-func (c *Client) GetTableAuditFlags(ctx context.Context, tableNames []string) (map[string]bool, error) {
-	out := make(map[string]bool, len(tableNames))
-	if len(tableNames) == 0 {
-		return out, nil
-	}
-
-	var resp DictionaryResponse
-	// Only the table-level record (element empty) carries the table's audit flag.
-	query := "nameIN" + strings.Join(tableNames, ",") + "^elementISEMPTY"
-	reqOpts := []ReqOpt{
-		WithQuery(query),
-		WithFields("name", "element", "audit"),
-	}
-	pv := PaginationVars{Limit: len(tableNames) + 1}
-	reqOpts = append(reqOpts, paginationVarsToReqOptions(&pv)...)
-
-	_, err := c.get(ctx, c.apiURL(DictionaryBaseUrl, c.deployment), &resp, reqOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("baton-servicenow: failed to read sys_dictionary audit flags: %w", err)
-	}
-
-	for i := range resp.Result {
-		r := &resp.Result[i]
-		if r.Element != "" {
-			continue
-		}
-		out[r.Name] = boolStr(r.Audit)
-	}
-	return out, nil
 }
 
 // GetAuditDeletedTables returns the tables listed in glide.ui.audit_deleted_tables

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -34,6 +34,16 @@ const (
 	GroupMembersBaseUrl      = TableAPIBaseURL + "/sys_user_grmember"
 	GroupMemberDetailBaseUrl = GroupMembersBaseUrl + "/%s"
 
+	// AuditDeleteBaseUrl is the sys_audit_delete table: one row per hard delete
+	// of an audited record. The event feed reads it to emit grant-revoke events.
+	AuditDeleteBaseUrl = TableAPIBaseURL + "/sys_audit_delete"
+
+	// AuditBaseUrl is the sys_audit table: one row per field-level change of an
+	// audited record (tablename/documentkey/fieldname/oldvalue/newvalue). The
+	// event feed reads it to surface account changes (sys_user) and audited
+	// deletes (fieldname=="DELETED") on the access tables in near real time.
+	AuditBaseUrl = TableAPIBaseURL + "/sys_audit"
+
 	RolesBaseUrl           = TableAPIBaseURL + "/sys_user_role"
 	UserRolesBaseUrl       = TableAPIBaseURL + "/sys_user_has_role"
 	UserRoleDetailBaseUrl  = UserRolesBaseUrl + "/%s"
@@ -69,6 +79,23 @@ const (
 	ChoiceBaseUrl = TableAPIBaseURL + "/sys_choice"
 
 	InstanceURLTemplate = `{{.Deployment}}.service-now.com`
+
+	// DictionaryBaseUrl is the sys_dictionary table: the data dictionary. Each row
+	// describes a table (when its `element` is empty — the table-level collection
+	// record) or a column. Its `audit` flag is the connector-readable signal for
+	// whether field-change auditing is enabled (drives sys_audit), used by the
+	// event-feed audit-config preflight.
+	DictionaryBaseUrl = TableAPIBaseURL + "/sys_dictionary"
+
+	// PropertyBaseUrl is the sys_properties table (system properties). The
+	// event-feed revoke-detection preflight reads the glide.ui.audit_deleted_tables
+	// row from it: the comma-separated list of tables whose hard deletes are
+	// captured to sys_audit_delete (the grant-REVOKE source).
+	PropertyBaseUrl = TableAPIBaseURL + "/sys_properties"
+
+	// AuditDeletedTablesProperty is the sys_properties name whose value lists the
+	// tables whose deletes are recorded in sys_audit_delete.
+	AuditDeletedTablesProperty = "glide.ui.audit_deleted_tables"
 
 	// Variable sets & variables (Table API).
 	VariableSetM2MBaseUrl = TableAPIBaseURL + "/io_set_item"
@@ -163,6 +190,278 @@ func (c *Client) GetBaseURL() string {
 	return c.baseURL
 }
 
+// AuditDeletePayloadFields is the field set fetched from sys_audit_delete for
+// the event feed. It adds `payload` (the full XML dump of the deleted row) on
+// top of AuditDeleteFields so the feed can resolve a deleted join row back to
+// its (principal, target) pair and emit a revoke event.
+var AuditDeletePayloadFields = []string{"tablename", fieldDocumentKey, "sys_created_on", "payload"}
+
+// GetDeletedSincePayload lists sys_audit_delete rows for one or more tables
+// whose delete was logged at or after createdSince ("YYYY-MM-DD HH:MM:SS",
+// UTC), INCLUDING the `payload` column and ordered by sys_created_on ascending
+// so the event feed advances its cursor monotonically. An empty createdSince
+// fetches from the beginning of the delete history. The returned next-page
+// token is the Table API offset for the following page ("" when exhausted).
+//
+// This is the event-feed delete source (it mirrors GetAuditSince's ordering and
+// GetDeletedSince's filtering, but additionally fetches the payload so deletes
+// of join rows become resolvable revoke events). Errors are surfaced to the
+// caller; the feed degrades gracefully and the periodic full sync remains the
+// source of truth.
+func (c *Client) GetDeletedSincePayload(ctx context.Context, tableNames []string, createdSince string, paginationVars PaginationVars) ([]AuditDeleteRecord, string, error) {
+	var resp AuditDeleteResponse
+
+	var query string
+	switch {
+	case len(tableNames) == 1:
+		query = fmt.Sprintf("tablename=%s", tableNames[0])
+	case len(tableNames) > 1:
+		query = "tablenameIN" + strings.Join(tableNames, ",")
+	}
+	if createdSince != "" {
+		clause := fmt.Sprintf("sys_created_on>=%s", createdSince)
+		if query != "" {
+			query += "^" + clause
+		} else {
+			query = clause
+		}
+	}
+	// Order ascending so paging walks forward in time from the cursor.
+	if query != "" {
+		query += "^ORDERBYsys_created_on"
+	} else {
+		query = "ORDERBYsys_created_on"
+	}
+
+	reqOpts := []ReqOpt{
+		WithQuery(query),
+		WithFields(AuditDeletePayloadFields...),
+	}
+	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
+
+	nextPage, err := c.get(ctx, c.apiURL(AuditDeleteBaseUrl, c.deployment), &resp, reqOpts...)
+	if err != nil {
+		return nil, "", err
+	}
+	return resp.Result, nextPage, nil
+}
+
+// fieldSysID/fieldUser are ServiceNow columns requested in the sysparm_fields
+// of the event-feed list calls.
+const (
+	fieldSysID       = "sys_id"
+	fieldUser        = "user"
+	fieldDocumentKey = "documentkey"
+)
+
+// AuditFields is the field set fetched from sys_audit for the event feed.
+var AuditFields = []string{fieldSysID, "tablename", fieldDocumentKey, "fieldname", "oldvalue", "newvalue", "sys_created_on", fieldUser}
+
+// GetAuditSince lists sys_audit rows for one or more tables whose change was
+// logged at or after createdSince ("YYYY-MM-DD HH:MM:SS", UTC), ordered by
+// sys_created_on ascending so the event feed advances its cursor monotonically.
+// An empty createdSince fetches from the beginning of the audit history. The
+// returned next-page token is the Table API offset for the following page (""
+// when exhausted).
+//
+// Note: an error here (e.g. auditing disabled, or the caller lacks read access
+// to sys_audit) is surfaced to the caller; the event feed degrades gracefully
+// and the periodic full sync remains the source of truth.
+func (c *Client) GetAuditSince(ctx context.Context, tableNames []string, createdSince string, paginationVars PaginationVars) ([]AuditRecord, string, error) {
+	var resp AuditResponse
+
+	var query string
+	switch {
+	case len(tableNames) == 1:
+		query = fmt.Sprintf("tablename=%s", tableNames[0])
+	case len(tableNames) > 1:
+		query = "tablenameIN" + strings.Join(tableNames, ",")
+	}
+	if createdSince != "" {
+		clause := fmt.Sprintf("sys_created_on>=%s", createdSince)
+		if query != "" {
+			query += "^" + clause
+		} else {
+			query = clause
+		}
+	}
+	// Order ascending so paging walks forward in time from the cursor.
+	if query != "" {
+		query += "^ORDERBYsys_created_on"
+	} else {
+		query = "ORDERBYsys_created_on"
+	}
+
+	reqOpts := []ReqOpt{
+		WithQuery(query),
+		WithFields(AuditFields...),
+	}
+	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
+
+	nextPage, err := c.get(ctx, c.apiURL(AuditBaseUrl, c.deployment), &resp, reqOpts...)
+	if err != nil {
+		return nil, "", err
+	}
+	return resp.Result, nextPage, nil
+}
+
+// GetTableAuditFlags reports, for each of the given table names, whether
+// field-change auditing is enabled on that table. It reads the table-level
+// collection record from sys_dictionary (the row where `element` is empty) and
+// returns a map tableName -> auditEnabled.
+//
+// The flag reflects sys_dictionary's `audit` column ("true"/"false"); a table
+// absent from the result (no table-level record returned, or unreadable) is
+// reported as false. This signals whether sys_audit field-change rows will be
+// produced — it does NOT reflect delete-recovery (sys_audit_delete), which is a
+// separate, independently-configured capability. Callers must treat this as
+// advisory only.
+func (c *Client) GetTableAuditFlags(ctx context.Context, tableNames []string) (map[string]bool, error) {
+	out := make(map[string]bool, len(tableNames))
+	if len(tableNames) == 0 {
+		return out, nil
+	}
+
+	var resp DictionaryResponse
+	// Only the table-level record carries the table's audit flag: name IN (...)
+	// AND element is empty.
+	query := "nameIN" + strings.Join(tableNames, ",") + "^elementISEMPTY"
+	reqOpts := []ReqOpt{
+		WithQuery(query),
+		WithFields("name", "element", "audit"),
+	}
+	pv := PaginationVars{Limit: len(tableNames) + 1}
+	reqOpts = append(reqOpts, paginationVarsToReqOptions(&pv)...)
+
+	_, err := c.get(ctx, c.apiURL(DictionaryBaseUrl, c.deployment), &resp, reqOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("baton-servicenow: failed to read sys_dictionary audit flags: %w", err)
+	}
+
+	for i := range resp.Result {
+		r := &resp.Result[i]
+		if r.Element != "" {
+			continue
+		}
+		out[r.Name] = boolStr(r.Audit)
+	}
+	return out, nil
+}
+
+// GetAuditDeletedTables reads the glide.ui.audit_deleted_tables system property
+// (sys_properties) and returns the list of table names whose hard deletes are
+// captured to sys_audit_delete. That capture is the source of near-real-time
+// grant-REVOKE events, so a join table's PRESENCE in this list means its revokes
+// are reliably captured.
+//
+// Caveat (do NOT treat absence as definitive): some tables can have their
+// deletes captured to sys_audit_delete by their own mechanism without appearing
+// in this property. So presence => reliably captured; absence => not reliably
+// captured via this property (but may still be captured by other means).
+// Callers must treat this as advisory only.
+//
+// An empty / unset property yields an empty list (no error). Errors (e.g. lack
+// of read access to sys_properties) are surfaced to the caller, which degrades
+// gracefully.
+func (c *Client) GetAuditDeletedTables(ctx context.Context) ([]string, error) {
+	var resp PropertyResponse
+	reqOpts := []ReqOpt{
+		WithQuery("name=" + AuditDeletedTablesProperty),
+		WithFields("name", "value"),
+	}
+	pv := PaginationVars{Limit: 1}
+	reqOpts = append(reqOpts, paginationVarsToReqOptions(&pv)...)
+
+	_, err := c.get(ctx, c.apiURL(PropertyBaseUrl, c.deployment), &resp, reqOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("baton-servicenow: failed to read %s system property: %w", AuditDeletedTablesProperty, err)
+	}
+
+	var tables []string
+	for i := range resp.Result {
+		if resp.Result[i].Name != AuditDeletedTablesProperty {
+			continue
+		}
+		for _, t := range strings.Split(resp.Result[i].Value, ",") {
+			if t = strings.TrimSpace(t); t != "" {
+				tables = append(tables, t)
+			}
+		}
+	}
+	return tables, nil
+}
+
+// CreatedSinceField is the ServiceNow column used as the event-feed cursor for
+// immutable join/assignment rows (which have no meaningful sys_updated_on).
+const CreatedSinceField = "sys_created_on"
+
+// appendCreatedSince ANDs a "sys_created_on>=<ts>^ORDERBYsys_created_on" clause
+// onto an existing query, ordering ascending so paging walks forward in time.
+// An empty ts orders without a lower bound (full pull).
+func appendCreatedSince(query string, ts string) string {
+	if ts != "" {
+		clause := fmt.Sprintf("%s>=%s", CreatedSinceField, ts)
+		if query != "" {
+			query += "^" + clause
+		} else {
+			query = clause
+		}
+	}
+	if query != "" {
+		return query + "^ORDERBY" + CreatedSinceField
+	}
+	return "ORDERBY" + CreatedSinceField
+}
+
+// GetGroupMembersCreatedSince lists sys_user_grmember rows created at or after
+// createdSince, ordered ascending. Each row's user/group are the principal and
+// target of a group-membership grant.
+func (c *Client) GetGroupMembersCreatedSince(ctx context.Context, createdSince string, paginationVars PaginationVars) ([]GroupMember, string, error) {
+	var resp GroupMembersResponse
+	reqOpts := []ReqOpt{
+		WithQuery(appendCreatedSince("", createdSince)),
+		WithFields(fieldSysID, fieldUser, "group", "sys_created_on"),
+	}
+	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
+	next, err := c.get(ctx, c.apiURL(GroupMembersBaseUrl, c.deployment), &resp, reqOpts...)
+	if err != nil {
+		return nil, "", err
+	}
+	return resp.Result, next, nil
+}
+
+// GetUserRolesCreatedSince lists sys_user_has_role rows created at or after
+// createdSince, ordered ascending (user/role = principal/target of a grant).
+func (c *Client) GetUserRolesCreatedSince(ctx context.Context, createdSince string, paginationVars PaginationVars) ([]UserToRole, string, error) {
+	var resp ListResponse[UserToRole]
+	reqOpts := []ReqOpt{
+		WithQuery(appendCreatedSince("", createdSince)),
+		WithFields(fieldSysID, fieldUser, "role", "inherited", "sys_created_on"),
+	}
+	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
+	next, err := c.get(ctx, c.apiURL(UserRolesBaseUrl, c.deployment), &resp, reqOpts...)
+	if err != nil {
+		return nil, "", err
+	}
+	return resp.Result, next, nil
+}
+
+// GetGroupRolesCreatedSince lists sys_group_has_role rows created at or after
+// createdSince, ordered ascending (group/role = principal/target of a grant).
+func (c *Client) GetGroupRolesCreatedSince(ctx context.Context, createdSince string, paginationVars PaginationVars) ([]GroupToRole, string, error) {
+	var resp ListResponse[GroupToRole]
+	reqOpts := []ReqOpt{
+		WithQuery(appendCreatedSince("", createdSince)),
+		WithFields(fieldSysID, "group", "role", "inherits", "sys_created_on"),
+	}
+	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
+	next, err := c.get(ctx, c.apiURL(GroupRolesBaseUrl, c.deployment), &resp, reqOpts...)
+	if err != nil {
+		return nil, "", err
+	}
+	return resp.Result, next, nil
+}
+
 // apiURL builds an API URL from a constant pattern like UsersBaseUrl.
 // When a base URL override is set, it replaces the default
 // https://DEPLOYMENT.service-now.com/api prefix with the override.
@@ -177,9 +476,19 @@ func (c *Client) apiURL(pattern string, args ...any) string {
 
 // Table `sys_user` (Users).
 func (c *Client) GetUsers(ctx context.Context, paginationVars PaginationVars) ([]User, string, error) {
+	return c.GetUsersUpdatedSince(ctx, paginationVars, "")
+}
+
+// GetUsersUpdatedSince lists users optionally restricted to those whose
+// sys_updated_on is at or after updatedSince. When updatedSince is empty it
+// behaves identically to GetUsers (full pull). The event feed's account-change
+// phase passes the cursor watermark to surface created/modified/disabled accounts.
+func (c *Client) GetUsersUpdatedSince(ctx context.Context, paginationVars PaginationVars, updatedSince string) ([]User, string, error) {
 	var usersResponse UsersResponse
 
-	reqOpts := filterToReqOptions(prepareUserFilters(c.AllowedDomains, c.CustomUserFields))
+	filters := prepareUserFilters(c.AllowedDomains, c.CustomUserFields)
+	filters.Query = appendUpdatedSince(filters.Query, updatedSince)
+	reqOpts := filterToReqOptions(filters)
 	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
 
 	nextPage, err := c.get(
@@ -215,9 +524,17 @@ func (c *Client) GetUser(ctx context.Context, userId string) (*User, error) {
 
 // Table `sys_user_group` (Groups).
 func (c *Client) GetGroups(ctx context.Context, paginationVars PaginationVars, groupIDs []string) ([]Group, string, error) {
+	return c.GetGroupsUpdatedSince(ctx, paginationVars, groupIDs, "")
+}
+
+// GetGroupsUpdatedSince lists groups optionally restricted to those updated at
+// or after updatedSince. Empty updatedSince == full pull.
+func (c *Client) GetGroupsUpdatedSince(ctx context.Context, paginationVars PaginationVars, groupIDs []string, updatedSince string) ([]Group, string, error) {
 	var groupsResponse GroupsResponse
 
-	reqOpts := filterToReqOptions(prepareGroupFilters(groupIDs))
+	filters := prepareGroupFilters(groupIDs)
+	filters.Query = appendUpdatedSince(filters.Query, updatedSince)
+	reqOpts := filterToReqOptions(filters)
 	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
 	nextPageToken, err := c.get(
 		ctx,
@@ -252,9 +569,17 @@ func (c *Client) GetGroup(ctx context.Context, groupId string) (*Group, error) {
 
 // Table `sys_user_grmember` (Group Members).
 func (c *Client) GetUserToGroup(ctx context.Context, userId string, groupId string, paginationVars PaginationVars) ([]GroupMember, string, error) {
+	return c.GetUserToGroupUpdatedSince(ctx, userId, groupId, paginationVars, "")
+}
+
+// GetUserToGroupUpdatedSince lists group-membership rows optionally restricted
+// to those updated at or after updatedSince. Empty updatedSince == full pull.
+func (c *Client) GetUserToGroupUpdatedSince(ctx context.Context, userId string, groupId string, paginationVars PaginationVars, updatedSince string) ([]GroupMember, string, error) {
 	var groupMembersResponse GroupMembersResponse
 
-	reqOpts := filterToReqOptions(prepareUserToGroupFilter(userId, groupId))
+	filters := prepareUserToGroupFilter(userId, groupId)
+	filters.Query = appendUpdatedSince(filters.Query, updatedSince)
+	reqOpts := filterToReqOptions(filters)
 	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
 
 	nextPageToken, err := c.get(
@@ -291,10 +616,18 @@ func (c *Client) RemoveUserFromGroup(ctx context.Context, id string) error {
 
 // Table `sys_user_role` (Roles).
 func (c *Client) GetRoles(ctx context.Context, paginationVars PaginationVars) ([]Role, string, error) {
+	return c.GetRolesUpdatedSince(ctx, paginationVars, "")
+}
+
+// GetRolesUpdatedSince lists roles optionally restricted to those updated at or
+// after updatedSince. Empty updatedSince == full pull.
+func (c *Client) GetRolesUpdatedSince(ctx context.Context, paginationVars PaginationVars, updatedSince string) ([]Role, string, error) {
 	var rolesResponse RolesResponse
 
 	paginationVars.Limit++
-	reqOpts := filterToReqOptions(prepareRoleFilters())
+	filters := prepareRoleFilters()
+	filters.Query = appendUpdatedSince(filters.Query, updatedSince)
+	reqOpts := filterToReqOptions(filters)
 	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
 
 	nextPageToken, err := c.get(
@@ -313,9 +646,17 @@ func (c *Client) GetRoles(ctx context.Context, paginationVars PaginationVars) ([
 
 // Table `sys_user_has_role` (User to Role).
 func (c *Client) GetUserToRole(ctx context.Context, userId string, roleId string, paginationVars PaginationVars) ([]UserToRole, string, error) {
+	return c.GetUserToRoleUpdatedSince(ctx, userId, roleId, paginationVars, "")
+}
+
+// GetUserToRoleUpdatedSince lists user-role rows optionally restricted to those
+// updated at or after updatedSince. Empty updatedSince == full pull.
+func (c *Client) GetUserToRoleUpdatedSince(ctx context.Context, userId string, roleId string, paginationVars PaginationVars, updatedSince string) ([]UserToRole, string, error) {
 	var userToRoleResponse UserToRoleResponse
 
-	reqOpts := filterToReqOptions(prepareUserToRoleFilter(userId, roleId))
+	filters := prepareUserToRoleFilter(userId, roleId)
+	filters.Query = appendUpdatedSince(filters.Query, updatedSince)
+	reqOpts := filterToReqOptions(filters)
 	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
 
 	nextPageToken, err := c.get(
@@ -352,9 +693,17 @@ func (c *Client) RevokeRoleFromUser(ctx context.Context, id string) error {
 
 // Table `sys_group_has_role` (Group to Role).
 func (c *Client) GetGroupToRole(ctx context.Context, groupId string, roleId string, paginationVars PaginationVars) ([]GroupToRole, string, error) {
+	return c.GetGroupToRoleUpdatedSince(ctx, groupId, roleId, paginationVars, "")
+}
+
+// GetGroupToRoleUpdatedSince lists group-role rows optionally restricted to
+// those updated at or after updatedSince. Empty updatedSince == full pull.
+func (c *Client) GetGroupToRoleUpdatedSince(ctx context.Context, groupId string, roleId string, paginationVars PaginationVars, updatedSince string) ([]GroupToRole, string, error) {
 	var groupToRoleResponse GroupToRoleResponse
 
-	reqOpts := filterToReqOptions(prepareGroupToRoleFilter(groupId, roleId))
+	filters := prepareGroupToRoleFilter(groupId, roleId)
+	filters.Query = appendUpdatedSince(filters.Query, updatedSince)
+	reqOpts := filterToReqOptions(filters)
 	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
 	nextPageToken, err := c.get(
 		ctx,

--- a/pkg/servicenow/model.go
+++ b/pkg/servicenow/model.go
@@ -16,9 +16,7 @@ import (
 const SystemAdminUserId = "6816f79cc0a8016401c5a33be04be441"
 
 // Table names backing the connector's resources/grants, used as the
-// sys_audit_delete `tablename` filter for deletion capture. The join tables
-// (TableUserGroupMember, TableUserHasRole, TableGroupHasRole) carry the
-// membership/assignment row sys_id in sys_audit_delete.documentkey.
+// sys_audit_delete `tablename` filter for deletion capture.
 const (
 	TableUser            = "sys_user"
 	TableUserGroup       = "sys_user_group"
@@ -150,51 +148,23 @@ type UserRoles struct {
 	FromGroup []string `json:"from_group"`
 }
 
-// AuditDeleteRecord is a row from the sys_audit_delete table. ServiceNow logs a
-// row here for every HARD delete of an audited record. The event feed reads it
-// to emit near-real-time grant-revoke events for deleted membership/assignment
-// rows.
-//
-//   - Tablename:    the table the deleted row belonged to (e.g. "sys_user").
-//   - DocumentKey:  the sys_id of the DELETED row. For a join table
-//     (sys_user_grmember / sys_user_has_role / sys_group_has_role) this is the
-//     membership/assignment row's sys_id, NOT the user/group/role sys_id.
-//   - SysCreatedOn: when the delete was logged ("YYYY-MM-DD HH:MM:SS", UTC). Used
-//     to advance the per-deployment delete watermark.
+// AuditDeleteRecord is a sys_audit_delete row (one per hard delete). DocumentKey
+// is the deleted row's sys_id (for a join table, the membership/assignment row).
 type AuditDeleteRecord struct {
 	Tablename    string `json:"tablename"`
 	DocumentKey  string `json:"documentkey"`
 	SysCreatedOn string `json:"sys_created_on"`
 
-	// Payload is the full XML serialization of the DELETED row, present when
-	// ServiceNow's delete-recovery/audit-delete capture is enabled (the default
-	// on most instances). It contains every column of the deleted row, including
-	// reference fields as elements whose text is the referenced sys_id. The
-	// event feed parses it to resolve a deleted join row back to its
-	// (principal, target) pair so it can emit a near-real-time revoke event.
-	//
-	// Only populated when the row is fetched via GetDeletedSincePayload. May be
-	// empty if delete-recovery is disabled for the table.
+	// Payload is the deleted row's full XML (reference fields as elements holding
+	// the referenced sys_id); the feed parses it to resolve a revoke. Only set via
+	// GetDeletedSincePayload, and empty if delete-recovery is disabled.
 	Payload string `json:"payload"`
 }
 
 type AuditDeleteResponse = ListResponse[AuditDeleteRecord]
 
-// AuditRecord is a row from the sys_audit table. ServiceNow logs a row here for
-// every field-level change of an audited record (and a synthetic row with
-// Fieldname=="DELETED" when an audited record is hard-deleted). The event feed
-// reads this table as its near-real-time change source, mirroring how the Okta
-// connector reads the Okta System Log.
-//
-//   - Tablename:    the table the changed row belongs to (e.g. "sys_user").
-//   - DocumentKey:  the sys_id of the changed row. For a join table this is the
-//     membership/assignment row's sys_id, NOT the user/group/role sys_id.
-//   - Fieldname:    the column that changed, or "DELETED" for a hard delete.
-//   - OldValue / NewValue: the before/after values of the changed field.
-//   - SysCreatedOn: when the change was logged ("YYYY-MM-DD HH:MM:SS", UTC).
-//     Used as the event-feed cursor (sys_created_on>=earliestEvent).
-//   - User:         the user who made the change (sys_created_by login name).
-//   - SysID:        the sys_audit row's own sys_id; used as the event Id.
+// AuditRecord is a sys_audit row: one per field change, plus a synthetic
+// Fieldname=="DELETED" row on hard delete. DocumentKey is the changed row's sys_id.
 type AuditRecord struct {
 	SysID        string `json:"sys_id"`
 	Tablename    string `json:"tablename"`
@@ -208,17 +178,8 @@ type AuditRecord struct {
 
 type AuditResponse = ListResponse[AuditRecord]
 
-// DictionaryRecord is a row from the sys_dictionary (data dictionary) table.
-// The event-feed preflight reads only the table-level collection record for each
-// table (the row whose Element is empty) to learn its Audit flag.
-//
-//   - Name:    the table the row describes (e.g. "sys_user").
-//   - Element: the column the row describes; EMPTY for the table-level record.
-//   - Audit:   ServiceNow stores booleans as the strings "true"/"false". On the
-//     table-level record this is the table's field-change auditing flag (drives
-//     sys_audit). NOTE: it does NOT report delete-recovery (sys_audit_delete),
-//     which is governed separately, so a table can have Audit=="false" yet still
-//     log deletes to sys_audit_delete.
+// DictionaryRecord is a sys_dictionary row. The table-level record (Element
+// empty) carries the table's field-change Audit flag ("true"/"false").
 type DictionaryRecord struct {
 	Name    string `json:"name"`
 	Element string `json:"element"`
@@ -227,11 +188,7 @@ type DictionaryRecord struct {
 
 type DictionaryResponse = ListResponse[DictionaryRecord]
 
-// PropertyRecord is a row from the sys_properties (system properties) table. The
-// event-feed revoke-detection preflight reads the single row named
-// glide.ui.audit_deleted_tables, whose Value is the comma-separated list of
-// tables whose hard deletes are captured to sys_audit_delete (the grant-REVOKE
-// source).
+// PropertyRecord is a sys_properties row (name/value system property).
 type PropertyRecord struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`

--- a/pkg/servicenow/model.go
+++ b/pkg/servicenow/model.go
@@ -15,6 +15,30 @@ import (
 
 const SystemAdminUserId = "6816f79cc0a8016401c5a33be04be441"
 
+// Table names backing the connector's resources/grants, used as the
+// sys_audit_delete `tablename` filter for deletion capture. The join tables
+// (TableUserGroupMember, TableUserHasRole, TableGroupHasRole) carry the
+// membership/assignment row sys_id in sys_audit_delete.documentkey.
+const (
+	TableUser            = "sys_user"
+	TableUserGroup       = "sys_user_group"
+	TableUserRole        = "sys_user_role"
+	TableUserGroupMember = "sys_user_grmember"
+	TableUserHasRole     = "sys_user_has_role"
+	TableGroupHasRole    = "sys_group_has_role"
+)
+
+// AuditedTables is every connector table the event feed scans in sys_audit for
+// near-real-time changes (today only sys_user changes/deletes map to events).
+var AuditedTables = []string{
+	TableUser,
+	TableUserGroup,
+	TableUserRole,
+	TableUserGroupMember,
+	TableUserHasRole,
+	TableGroupHasRole,
+}
+
 type BaseResource struct {
 	Id string `json:"sys_id"`
 }
@@ -27,6 +51,7 @@ type User struct {
 	UserName     string            `json:"user_name"`
 	Roles        string            `json:"roles"`
 	Active       string            `json:"active"`
+	SysUpdatedOn string            `json:"sys_updated_on"`
 	CustomFields map[string]string `json:"-"`
 }
 
@@ -64,21 +89,26 @@ func (u *User) UnmarshalJSON(data []byte) error {
 
 type Role struct {
 	BaseResource
-	Name      string `json:"name"`
-	Grantable string `json:"grantable"`
+	Name         string `json:"name"`
+	Grantable    string `json:"grantable"`
+	SysUpdatedOn string `json:"sys_updated_on"`
 }
 
 type Group struct {
 	BaseResource
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Roles       string `json:"roles"`
+	Name         string `json:"name"`
+	Description  string `json:"description"`
+	Roles        string `json:"roles"`
+	Manager      string `json:"manager"`
+	SysUpdatedOn string `json:"sys_updated_on"`
 }
 
 type GroupMember struct {
 	BaseResource
-	User  string `json:"user"`
-	Group string `json:"group"`
+	User         string `json:"user"`
+	Group        string `json:"group"`
+	SysUpdatedOn string `json:"sys_updated_on"`
+	SysCreatedOn string `json:"sys_created_on"`
 }
 
 type GroupMemberPayload struct {
@@ -88,9 +118,11 @@ type GroupMemberPayload struct {
 
 type UserToRole struct {
 	BaseResource
-	Inherited string `json:"inherited"`
-	User      string `json:"user"`
-	Role      string `json:"role"`
+	Inherited    string `json:"inherited"`
+	User         string `json:"user"`
+	Role         string `json:"role"`
+	SysUpdatedOn string `json:"sys_updated_on"`
+	SysCreatedOn string `json:"sys_created_on"`
 }
 
 type UserToRolePayload struct {
@@ -100,9 +132,11 @@ type UserToRolePayload struct {
 
 type GroupToRole struct {
 	BaseResource
-	Inherits string `json:"inherits"`
-	Group    string `json:"group"`
-	Role     string `json:"role"`
+	Inherits     string `json:"inherits"`
+	Group        string `json:"group"`
+	Role         string `json:"role"`
+	SysUpdatedOn string `json:"sys_updated_on"`
+	SysCreatedOn string `json:"sys_created_on"`
 }
 
 type GroupToRolePayload struct {
@@ -115,6 +149,95 @@ type UserRoles struct {
 	FromRole  []string `json:"from_role"`
 	FromGroup []string `json:"from_group"`
 }
+
+// AuditDeleteRecord is a row from the sys_audit_delete table. ServiceNow logs a
+// row here for every HARD delete of an audited record. The event feed reads it
+// to emit near-real-time grant-revoke events for deleted membership/assignment
+// rows.
+//
+//   - Tablename:    the table the deleted row belonged to (e.g. "sys_user").
+//   - DocumentKey:  the sys_id of the DELETED row. For a join table
+//     (sys_user_grmember / sys_user_has_role / sys_group_has_role) this is the
+//     membership/assignment row's sys_id, NOT the user/group/role sys_id.
+//   - SysCreatedOn: when the delete was logged ("YYYY-MM-DD HH:MM:SS", UTC). Used
+//     to advance the per-deployment delete watermark.
+type AuditDeleteRecord struct {
+	Tablename    string `json:"tablename"`
+	DocumentKey  string `json:"documentkey"`
+	SysCreatedOn string `json:"sys_created_on"`
+
+	// Payload is the full XML serialization of the DELETED row, present when
+	// ServiceNow's delete-recovery/audit-delete capture is enabled (the default
+	// on most instances). It contains every column of the deleted row, including
+	// reference fields as elements whose text is the referenced sys_id. The
+	// event feed parses it to resolve a deleted join row back to its
+	// (principal, target) pair so it can emit a near-real-time revoke event.
+	//
+	// Only populated when the row is fetched via GetDeletedSincePayload. May be
+	// empty if delete-recovery is disabled for the table.
+	Payload string `json:"payload"`
+}
+
+type AuditDeleteResponse = ListResponse[AuditDeleteRecord]
+
+// AuditRecord is a row from the sys_audit table. ServiceNow logs a row here for
+// every field-level change of an audited record (and a synthetic row with
+// Fieldname=="DELETED" when an audited record is hard-deleted). The event feed
+// reads this table as its near-real-time change source, mirroring how the Okta
+// connector reads the Okta System Log.
+//
+//   - Tablename:    the table the changed row belongs to (e.g. "sys_user").
+//   - DocumentKey:  the sys_id of the changed row. For a join table this is the
+//     membership/assignment row's sys_id, NOT the user/group/role sys_id.
+//   - Fieldname:    the column that changed, or "DELETED" for a hard delete.
+//   - OldValue / NewValue: the before/after values of the changed field.
+//   - SysCreatedOn: when the change was logged ("YYYY-MM-DD HH:MM:SS", UTC).
+//     Used as the event-feed cursor (sys_created_on>=earliestEvent).
+//   - User:         the user who made the change (sys_created_by login name).
+//   - SysID:        the sys_audit row's own sys_id; used as the event Id.
+type AuditRecord struct {
+	SysID        string `json:"sys_id"`
+	Tablename    string `json:"tablename"`
+	DocumentKey  string `json:"documentkey"`
+	Fieldname    string `json:"fieldname"`
+	OldValue     string `json:"oldvalue"`
+	NewValue     string `json:"newvalue"`
+	SysCreatedOn string `json:"sys_created_on"`
+	User         string `json:"user"`
+}
+
+type AuditResponse = ListResponse[AuditRecord]
+
+// DictionaryRecord is a row from the sys_dictionary (data dictionary) table.
+// The event-feed preflight reads only the table-level collection record for each
+// table (the row whose Element is empty) to learn its Audit flag.
+//
+//   - Name:    the table the row describes (e.g. "sys_user").
+//   - Element: the column the row describes; EMPTY for the table-level record.
+//   - Audit:   ServiceNow stores booleans as the strings "true"/"false". On the
+//     table-level record this is the table's field-change auditing flag (drives
+//     sys_audit). NOTE: it does NOT report delete-recovery (sys_audit_delete),
+//     which is governed separately, so a table can have Audit=="false" yet still
+//     log deletes to sys_audit_delete.
+type DictionaryRecord struct {
+	Name    string `json:"name"`
+	Element string `json:"element"`
+	Audit   string `json:"audit"`
+}
+
+type DictionaryResponse = ListResponse[DictionaryRecord]
+
+// PropertyRecord is a row from the sys_properties (system properties) table. The
+// event-feed revoke-detection preflight reads the single row named
+// glide.ui.audit_deleted_tables, whose Value is the comma-separated list of
+// tables whose hard deletes are captured to sys_audit_delete (the grant-REVOKE
+// source).
+type PropertyRecord struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type PropertyResponse = ListResponse[PropertyRecord]
 
 // TODO(lauren) remove unecessary fields.
 // Service Catalog request models.

--- a/pkg/servicenow/model.go
+++ b/pkg/servicenow/model.go
@@ -178,16 +178,6 @@ type AuditRecord struct {
 
 type AuditResponse = ListResponse[AuditRecord]
 
-// DictionaryRecord is a sys_dictionary row. The table-level record (Element
-// empty) carries the table's field-change Audit flag ("true"/"false").
-type DictionaryRecord struct {
-	Name    string `json:"name"`
-	Element string `json:"element"`
-	Audit   string `json:"audit"`
-}
-
-type DictionaryResponse = ListResponse[DictionaryRecord]
-
 // PropertyRecord is a sys_properties row (name/value system property).
 type PropertyRecord struct {
 	Name  string `json:"name"`

--- a/pkg/servicenow/request.go
+++ b/pkg/servicenow/request.go
@@ -8,10 +8,31 @@ import (
 )
 
 var (
-	UserFields  = []string{"sys_id", "name", "roles", "user_name", "email", "first_name", "last_name", "active"}
-	RoleFields  = []string{"sys_id", "grantable", "name"}
-	GroupFields = []string{"sys_id", "description", "name"}
+	UserFields  = []string{"sys_id", "name", "roles", "user_name", "email", "first_name", "last_name", "active", "sys_updated_on"}
+	RoleFields  = []string{"sys_id", "grantable", "name", "sys_updated_on"}
+	GroupFields = []string{"sys_id", "description", "name", "manager", "sys_updated_on"}
 )
+
+// UpdatedSinceField is the ServiceNow column used to filter rows by last-change
+// time. Every Table API row carries it; comparisons in sysparm_query are
+// evaluated in the API caller's session timezone (UTC for typical integration
+// accounts), and the value is itself a UTC "YYYY-MM-DD HH:MM:SS".
+const UpdatedSinceField = "sys_updated_on"
+
+// WithUpdatedSince appends a "sys_updated_on>=<ts>" clause to an existing
+// FilterVars query, returning a watermark-filtered query string. ts must be
+// a ServiceNow datetime literal ("YYYY-MM-DD HH:MM:SS"). An empty ts is a
+// no-op (full pull). The clause is ANDed (^) with any existing query.
+func appendUpdatedSince(query string, ts string) string {
+	if ts == "" {
+		return query
+	}
+	clause := fmt.Sprintf("%s>=%s", UpdatedSinceField, ts)
+	if query == "" {
+		return clause
+	}
+	return query + "^" + clause
+}
 
 func queryMultipleIDs(ids []string) string {
 	var preparedIDs []string
@@ -150,7 +171,7 @@ func prepareUserToGroupFilter(userId string, groupId string) *FilterVars {
 
 	return &FilterVars{
 		Fields: []string{
-			"sys_id", "user", "group",
+			"sys_id", "user", "group", "sys_updated_on",
 		},
 		Query: query,
 	}
@@ -172,7 +193,7 @@ func prepareUserToRoleFilter(userId string, roleId string) *FilterVars {
 
 	return &FilterVars{
 		Fields: []string{
-			"sys_id", "user", "role", "inherited",
+			"sys_id", "user", "role", "inherited", "sys_updated_on",
 		},
 		Query: query,
 	}
@@ -194,7 +215,7 @@ func prepareGroupToRoleFilter(groupId string, roleId string) *FilterVars {
 
 	return &FilterVars{
 		Fields: []string{
-			"sys_id", "role", "group", "inherits",
+			"sys_id", "role", "group", "inherits", "sys_updated_on",
 		},
 		Query: query,
 	}

--- a/pkg/servicenow/request.go
+++ b/pkg/servicenow/request.go
@@ -21,19 +21,22 @@ var (
 // accounts), and the value is itself a UTC "YYYY-MM-DD HH:MM:SS".
 const UpdatedSinceField = "sys_updated_on"
 
-// WithUpdatedSince appends a "sys_updated_on>=<ts>" clause to an existing
-// FilterVars query, returning a watermark-filtered query string. ts must be
-// a ServiceNow datetime literal ("YYYY-MM-DD HH:MM:SS"). An empty ts is a
-// no-op (full pull). The clause is ANDed (^) with any existing query.
+// appendUpdatedSince appends a "sys_updated_on>=<ts>^ORDERBYsys_updated_on"
+// clause to an existing FilterVars query. ts must be a ServiceNow datetime
+// literal ("YYYY-MM-DD HH:MM:SS"). An empty ts is a no-op (full pull, no
+// ordering imposed). When ts is set, the clause is ANDed (^) with any existing
+// query and an ascending sys_updated_on sort is appended so offset pagination
+// walks forward deterministically; without it the Table API may return rows in
+// an unstable order across pages, silently skipping or duplicating them.
 func appendUpdatedSince(query string, ts string) string {
 	if ts == "" {
 		return query
 	}
 	clause := fmt.Sprintf("%s>=%s", UpdatedSinceField, ts)
-	if query == "" {
-		return clause
+	if query != "" {
+		clause = query + "^" + clause
 	}
-	return query + "^" + clause
+	return clause + "^ORDERBY" + UpdatedSinceField
 }
 
 func queryMultipleIDs(ids []string) string {

--- a/pkg/servicenow/request.go
+++ b/pkg/servicenow/request.go
@@ -7,10 +7,12 @@ import (
 	"strings"
 )
 
+const fieldName = "name"
+
 var (
-	UserFields  = []string{"sys_id", "name", "roles", "user_name", "email", "first_name", "last_name", "active", "sys_updated_on"}
-	RoleFields  = []string{"sys_id", "grantable", "name", "sys_updated_on"}
-	GroupFields = []string{"sys_id", "description", "name", "manager", "sys_updated_on"}
+	UserFields  = []string{fieldSysID, fieldName, "roles", "user_name", "email", "first_name", "last_name", "active", UpdatedSinceField}
+	RoleFields  = []string{fieldSysID, "grantable", fieldName, UpdatedSinceField}
+	GroupFields = []string{fieldSysID, "description", fieldName, "manager", UpdatedSinceField}
 )
 
 // UpdatedSinceField is the ServiceNow column used to filter rows by last-change
@@ -171,7 +173,7 @@ func prepareUserToGroupFilter(userId string, groupId string) *FilterVars {
 
 	return &FilterVars{
 		Fields: []string{
-			"sys_id", "user", "group", "sys_updated_on",
+			fieldSysID, "user", "group", UpdatedSinceField,
 		},
 		Query: query,
 	}
@@ -193,7 +195,7 @@ func prepareUserToRoleFilter(userId string, roleId string) *FilterVars {
 
 	return &FilterVars{
 		Fields: []string{
-			"sys_id", "user", "role", "inherited", "sys_updated_on",
+			fieldSysID, "user", "role", "inherited", UpdatedSinceField,
 		},
 		Query: query,
 	}
@@ -215,7 +217,7 @@ func prepareGroupToRoleFilter(groupId string, roleId string) *FilterVars {
 
 	return &FilterVars{
 		Fields: []string{
-			"sys_id", "role", "group", "inherits", "sys_updated_on",
+			fieldSysID, "role", "group", "inherits", UpdatedSinceField,
 		},
 		Query: query,
 	}

--- a/vendor/go.uber.org/zap/zaptest/observer/logged_entry.go
+++ b/vendor/go.uber.org/zap/zaptest/observer/logged_entry.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package observer
+
+import "go.uber.org/zap/zapcore"
+
+// A LoggedEntry is an encoding-agnostic representation of a log message.
+// Field availability is context dependent.
+type LoggedEntry struct {
+	zapcore.Entry
+	Context []zapcore.Field
+}
+
+// ContextMap returns a map for all fields in Context.
+func (e LoggedEntry) ContextMap() map[string]interface{} {
+	encoder := zapcore.NewMapObjectEncoder()
+	for _, f := range e.Context {
+		f.AddTo(encoder)
+	}
+	return encoder.Fields
+}

--- a/vendor/go.uber.org/zap/zaptest/observer/observer.go
+++ b/vendor/go.uber.org/zap/zaptest/observer/observer.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2016-2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package observer provides a zapcore.Core that keeps an in-memory,
+// encoding-agnostic representation of log entries. It's useful for
+// applications that want to unit test their log output without tying their
+// tests to a particular output encoding.
+package observer // import "go.uber.org/zap/zaptest/observer"
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap/internal"
+	"go.uber.org/zap/zapcore"
+)
+
+// ObservedLogs is a concurrency-safe, ordered collection of observed logs.
+type ObservedLogs struct {
+	mu   sync.RWMutex
+	logs []LoggedEntry
+}
+
+// Len returns the number of items in the collection.
+func (o *ObservedLogs) Len() int {
+	o.mu.RLock()
+	n := len(o.logs)
+	o.mu.RUnlock()
+	return n
+}
+
+// All returns a copy of all the observed logs.
+func (o *ObservedLogs) All() []LoggedEntry {
+	o.mu.RLock()
+	ret := make([]LoggedEntry, len(o.logs))
+	copy(ret, o.logs)
+	o.mu.RUnlock()
+	return ret
+}
+
+// TakeAll returns a copy of all the observed logs, and truncates the observed
+// slice.
+func (o *ObservedLogs) TakeAll() []LoggedEntry {
+	o.mu.Lock()
+	ret := o.logs
+	o.logs = nil
+	o.mu.Unlock()
+	return ret
+}
+
+// AllUntimed returns a copy of all the observed logs, but overwrites the
+// observed timestamps with time.Time's zero value. This is useful when making
+// assertions in tests.
+func (o *ObservedLogs) AllUntimed() []LoggedEntry {
+	ret := o.All()
+	for i := range ret {
+		ret[i].Time = time.Time{}
+	}
+	return ret
+}
+
+// FilterLevelExact filters entries to those logged at exactly the given level.
+func (o *ObservedLogs) FilterLevelExact(level zapcore.Level) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return e.Level == level
+	})
+}
+
+// FilterMessage filters entries to those that have the specified message.
+func (o *ObservedLogs) FilterMessage(msg string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return e.Message == msg
+	})
+}
+
+// FilterLoggerName filters entries to those logged through logger with the specified logger name.
+func (o *ObservedLogs) FilterLoggerName(name string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return e.LoggerName == name
+	})
+}
+
+// FilterMessageSnippet filters entries to those that have a message containing the specified snippet.
+func (o *ObservedLogs) FilterMessageSnippet(snippet string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return strings.Contains(e.Message, snippet)
+	})
+}
+
+// FilterField filters entries to those that have the specified field.
+func (o *ObservedLogs) FilterField(field zapcore.Field) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		for _, ctxField := range e.Context {
+			if ctxField.Equals(field) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// FilterFieldKey filters entries to those that have the specified key.
+func (o *ObservedLogs) FilterFieldKey(key string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		for _, ctxField := range e.Context {
+			if ctxField.Key == key {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// Filter returns a copy of this ObservedLogs containing only those entries
+// for which the provided function returns true.
+func (o *ObservedLogs) Filter(keep func(LoggedEntry) bool) *ObservedLogs {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+
+	var filtered []LoggedEntry
+	for _, entry := range o.logs {
+		if keep(entry) {
+			filtered = append(filtered, entry)
+		}
+	}
+	return &ObservedLogs{logs: filtered}
+}
+
+func (o *ObservedLogs) add(log LoggedEntry) {
+	o.mu.Lock()
+	o.logs = append(o.logs, log)
+	o.mu.Unlock()
+}
+
+// New creates a new Core that buffers logs in memory (without any encoding).
+// It's particularly useful in tests.
+func New(enab zapcore.LevelEnabler) (zapcore.Core, *ObservedLogs) {
+	ol := &ObservedLogs{}
+	return &contextObserver{
+		LevelEnabler: enab,
+		logs:         ol,
+	}, ol
+}
+
+type contextObserver struct {
+	zapcore.LevelEnabler
+	logs    *ObservedLogs
+	context []zapcore.Field
+}
+
+var (
+	_ zapcore.Core            = (*contextObserver)(nil)
+	_ internal.LeveledEnabler = (*contextObserver)(nil)
+)
+
+func (co *contextObserver) Level() zapcore.Level {
+	return zapcore.LevelOf(co.LevelEnabler)
+}
+
+func (co *contextObserver) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if co.Enabled(ent.Level) {
+		return ce.AddCore(ent, co)
+	}
+	return ce
+}
+
+func (co *contextObserver) With(fields []zapcore.Field) zapcore.Core {
+	return &contextObserver{
+		LevelEnabler: co.LevelEnabler,
+		logs:         co.logs,
+		context:      append(co.context[:len(co.context):len(co.context)], fields...),
+	}
+}
+
+func (co *contextObserver) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	all := make([]zapcore.Field, 0, len(fields)+len(co.context))
+	all = append(all, co.context...)
+	all = append(all, fields...)
+	co.logs.add(LoggedEntry{ent, all})
+	return nil
+}
+
+func (co *contextObserver) Sync() error {
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -750,6 +750,7 @@ go.uber.org/zap/internal/exit
 go.uber.org/zap/internal/pool
 go.uber.org/zap/internal/stacktrace
 go.uber.org/zap/zapcore
+go.uber.org/zap/zaptest/observer
 # golang.org/x/crypto v0.50.0
 ## explicit; go 1.25.0
 golang.org/x/crypto/blowfish


### PR DESCRIPTION
Implements **CXH-1906** — feed-only, near-real-time change detection.

## What this adds
- `pkg/connector/event_feed.go` — event-feed syncer emitting Baton events (grant create/revoke, account change/delete) across a phased state machine with checkpointing, using `sys_audit` / `sys_audit_delete`.
- Supporting client/model/request additions in `pkg/servicenow`.
- Extensive tests (`event_feed_test.go`, ~650 LOC) using `zaptest/observer`.
- `revokeDetectionPreflight` warns (not silently skips) when the audit-tables property can't be read, so operators aren't blind to unverified revoke capture. `appendUpdatedSince` orders ascending for stable pagination of the user-change phase.

## Validation
- Normal full sync against dev289997 reproduces the baseline exactly (638 users / 55 groups / 733 roles / 4928 grants, exit 0) — the API-client additions don't regress base syncing.
- The feed pull runs in C1 service mode (not a local CLI path); that logic is covered by unit tests, and the shared `ORDERBY` change is verified complete/dup-free against the live Table API.
- `go build/vet/test` green; golangci-lint: 0 new findings vs main.

## Known follow-up
`revokeDetectionPreflight`'s gating signal (`glide.ui.audit_deleted_tables`) is an unreliable proxy — on the test instance it is empty yet hard deletes still produce `sys_audit_delete` rows. The true gating mechanism should be identified and the signal fixed or the warning softened.

## Merge-order note
Shares several `pkg/servicenow` symbols with the incremental-sync branch (CXH-1905). Whichever of the two merges second must rebase and drop the duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
