### PR TITLE
[CXP-723] fix: replace offset pagination with keyset pagination for ServiceNow identity/membership sync

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -103,7 +103,7 @@ func (s *ServiceNow) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error
 
 // Validates that we have credentials and an endpoint. Does not validate that the credentials have all of the correct permissions.
 func (s *ServiceNow) Validate(ctx context.Context) (annotations.Annotations, error) {
-	pagination := servicenow.PaginationVars{
+	pagination := servicenow.KeysetPaginationVars{
 		Limit: 1,
 	}
 

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -34,15 +34,12 @@ func groupResource(group *servicenow.Group) (*v2.Resource, error) {
 		"group_description": group.Description,
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
-
 	resource, err := rs.NewGroupResource(
 		group.Name,
 		resourceTypeGroup,
 		group.Id,
-		groupTraitOptions,
+		nil,
+		rs.WithResourceProfile(profile),
 	)
 
 	if err != nil {
@@ -53,16 +50,16 @@ func groupResource(group *servicenow.Group) (*v2.Resource, error) {
 }
 
 func (g *groupResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
-	bag, offset, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeGroup.Id})
+	bag, lastID, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeGroup.Id})
 	if err != nil {
 		return nil, "", nil, err
 	}
 
 	groups, nextPageToken, err := g.client.GetGroups(
 		ctx,
-		servicenow.PaginationVars{
+		servicenow.KeysetPaginationVars{
 			Limit:  ResourcesPageSize,
-			Offset: offset,
+			LastID: lastID,
 		},
 		nil,
 	)
@@ -109,18 +106,18 @@ func (g *groupResourceType) Entitlements(ctx context.Context, resource *v2.Resou
 }
 
 func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, pt *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	bag, offset, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeGroup.Id})
+	bag, lastID, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeGroup.Id})
 	if err != nil {
 		return nil, "", nil, err
 	}
 
 	groupMembers, nextPageToken, err := g.client.GetUserToGroup(
 		ctx,
-		"", // all users
+		"", // all users, domain-filtered when allowed-domains is set
 		resource.Id.Resource,
-		servicenow.PaginationVars{
+		servicenow.KeysetPaginationVars{
 			Limit:  ResourcesPageSize,
-			Offset: offset,
+			LastID: lastID,
 		},
 	)
 	if err != nil {
@@ -134,14 +131,14 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, p
 
 	memberIDs := mapGroupMembers(groupMembers)
 	if len(memberIDs) == 0 {
-		return []*v2.Grant{}, nextPageToken, nil, nil
+		return []*v2.Grant{}, nextPage, nil, nil
 	}
 
 	var rv []*v2.Grant
 	for _, member := range memberIDs {
 		rID, err := rs.NewResourceID(resourceTypeUser, member)
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("baton-servicenow: error creating principal id")
+			return nil, "", nil, fmt.Errorf("baton-servicenow: error creating principal id for member %s: %w", member, err)
 		}
 
 		// grant group membership
@@ -176,7 +173,7 @@ func (r *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 		ctx,
 		principal.Id.Resource,
 		groupId,
-		servicenow.PaginationVars{Limit: 1},
+		servicenow.KeysetPaginationVars{Limit: 1},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("baton-servicenow: failed to get group members for %s: %w", entitlement.Id, err)
@@ -227,7 +224,7 @@ func (r *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annota
 		ctx,
 		principal.Id.Resource,
 		groupId,
-		servicenow.PaginationVars{Limit: 1},
+		servicenow.KeysetPaginationVars{Limit: 1},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("baton-servicenow: failed to get user roles for %s: %w", grant.Principal.Id.Resource, err)

--- a/pkg/connector/group_test.go
+++ b/pkg/connector/group_test.go
@@ -1,0 +1,34 @@
+package connector
+
+import (
+	"testing"
+
+	"github.com/conductorone/baton-servicenow/pkg/servicenow"
+)
+
+// TestGroupResource_ProfileSurfacesOnResource guards against a regression
+// from moving the group profile from a GroupTrait option to a resource-level
+// option: the resource itself must still carry the profile fields.
+func TestGroupResource_ProfileSurfacesOnResource(t *testing.T) {
+	group := &servicenow.Group{
+		BaseResource: servicenow.BaseResource{Id: "group-1"},
+		Name:         "Admins",
+		Description:  "Administrators group",
+	}
+
+	resource, err := groupResource(group)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	profile := resource.GetProfile().AsMap()
+	if got := profile["group_name"]; got != "Admins" {
+		t.Errorf("profile[group_name] = %v, want %q", got, "Admins")
+	}
+	if got := profile["group_id"]; got != "group-1" {
+		t.Errorf("profile[group_id] = %v, want %q", got, "group-1")
+	}
+	if got := profile["group_description"]; got != "Administrators group" {
+		t.Errorf("profile[group_description] = %v, want %q", got, "Administrators group")
+	}
+}

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -1,14 +1,37 @@
 package connector
 
 import (
+	"fmt"
+	"regexp"
+	"strings"
+
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-servicenow/pkg/servicenow"
 )
 
-var ResourcesPageSize = 50
-var TicketSchemasPageSize = 25
+// ResourcesPageSize is the page size for the 6 keyset-paginated Table API
+// listings (users, roles, groups, membership). 200 cuts request count ~4x
+// vs the old 50 without pushing all the way to the Table API's 10,000 max.
+//
+// Note: GetUsers, GetUserToGroup, and GetUserToRole don't actually get 200
+// when AllowedDomains is configured -- cappedForDomainFilter forces their
+// limit back down to domainFilteredPageSize (50) for enumeration calls,
+// since the dot-walk filter (user.emailENDSWITH) can't use the sys_id
+// index and a bigger page means more server-side scan per request.
+const ResourcesPageSize = 200
+const TicketSchemasPageSize = 25
+
+// sysIDPattern matches a ServiceNow sys_id: 32 hex characters. ServiceNow's
+// storage collation is case-insensitive, so either case is accepted and
+// normalized to lowercase for a stable cursor.
+var sysIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{32}$`)
+
+// legacyOffsetPattern matches a pre-keyset sysparm_offset checkpoint token
+// (an all-digit string). Landing on one means a sync was in flight across
+// the keyset migration -- safe to restart that listing from scratch.
+var legacyOffsetPattern = regexp.MustCompile(`^[0-9]+$`)
 
 func annotationsForUserResourceType() annotations.Annotations {
 	annos := annotations.Annotations{}
@@ -16,11 +39,14 @@ func annotationsForUserResourceType() annotations.Annotations {
 	return annos
 }
 
-func parsePageToken(i string, resourceID *v2.ResourceId) (*pagination.Bag, int, error) {
+// parsePageToken returns the bag along with its current page token, which for
+// keyset-paginated resources (users, roles, groups, membership) is the last
+// seen sys_id rather than a numeric offset.
+func parsePageToken(i string, resourceID *v2.ResourceId) (*pagination.Bag, string, error) {
 	b := &pagination.Bag{}
 	err := b.Unmarshal(i)
 	if err != nil {
-		return nil, 0, err
+		return nil, "", err
 	}
 
 	if b.Current() == nil {
@@ -30,12 +56,22 @@ func parsePageToken(i string, resourceID *v2.ResourceId) (*pagination.Bag, int, 
 		})
 	}
 
-	page, err := convertPageToken(b.PageToken())
-	if err != nil {
-		return nil, 0, err
+	token := b.PageToken()
+	if token == "" {
+		return b, "", nil
 	}
 
-	return b, page, nil
+	// A valid sys_id cursor normalizes to lowercase; a legacy numeric
+	// offset token restarts the listing; anything else fails loudly
+	// instead of silently restarting, to avoid a possible infinite loop.
+	switch {
+	case sysIDPattern.MatchString(token):
+		return b, strings.ToLower(token), nil
+	case legacyOffsetPattern.MatchString(token):
+		return b, "", nil
+	default:
+		return nil, "", fmt.Errorf("baton-servicenow: malformed page token %q", token)
+	}
 }
 
 // convertPageToken converts a string token into an int.

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -28,11 +28,6 @@ const TicketSchemasPageSize = 25
 // normalized to lowercase for a stable cursor.
 var sysIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{32}$`)
 
-// legacyOffsetPattern matches a pre-keyset sysparm_offset checkpoint token
-// (an all-digit string). Landing on one means a sync was in flight across
-// the keyset migration -- safe to restart that listing from scratch.
-var legacyOffsetPattern = regexp.MustCompile(`^[0-9]+$`)
-
 func annotationsForUserResourceType() annotations.Annotations {
 	annos := annotations.Annotations{}
 	annos.Update(&v2.SkipEntitlementsAndGrants{})
@@ -61,17 +56,14 @@ func parsePageToken(i string, resourceID *v2.ResourceId) (*pagination.Bag, strin
 		return b, "", nil
 	}
 
-	// A valid sys_id cursor normalizes to lowercase; a legacy numeric
-	// offset token restarts the listing; anything else fails loudly
-	// instead of silently restarting, to avoid a possible infinite loop.
-	switch {
-	case sysIDPattern.MatchString(token):
-		return b, strings.ToLower(token), nil
-	case legacyOffsetPattern.MatchString(token):
-		return b, "", nil
-	default:
+	// A valid sys_id cursor normalizes to lowercase; anything else --
+	// including a pre-keyset numeric offset token -- fails loudly rather
+	// than guessing, since a wrong guess here means silently wrong
+	// pagination results, not just a restart.
+	if !sysIDPattern.MatchString(token) {
 		return nil, "", fmt.Errorf("baton-servicenow: malformed page token %q", token)
 	}
+	return b, strings.ToLower(token), nil
 }
 
 // convertPageToken converts a string token into an int.

--- a/pkg/connector/helpers_test.go
+++ b/pkg/connector/helpers_test.go
@@ -1,0 +1,98 @@
+package connector
+
+import (
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
+)
+
+// marshalPageToken builds the serialized bag token an SDK-driven sync would
+// pass back into List()/Grants() on the next page, given a resourceID and
+// whatever page token was checkpointed for it.
+func marshalPageToken(t *testing.T, resourceID *v2.ResourceId, checkpointedToken string) string {
+	t.Helper()
+
+	b := &pagination.Bag{}
+	if err := b.Unmarshal(""); err != nil {
+		t.Fatalf("unexpected error unmarshaling empty token: %v", err)
+	}
+	b.Push(pagination.PageState{
+		ResourceTypeID: resourceID.ResourceType,
+		ResourceID:     resourceID.Resource,
+	})
+
+	marshaled, err := b.NextToken(checkpointedToken)
+	if err != nil {
+		t.Fatalf("unexpected error building checkpointed token: %v", err)
+	}
+	return marshaled
+}
+
+// TestParsePageToken_TokenValidation covers the three shapes a checkpointed
+// page token can take: (1) a real sys_id passes through as the seek
+// cursor, normalized to lowercase; (2) a legacy numeric offset token
+// silently restarts the listing instead of being read as a literal sys_id
+// cursor; (3) anything else fails loudly instead of silently restarting,
+// to avoid a possible infinite loop.
+func TestParsePageToken_TokenValidation(t *testing.T) {
+	resourceID := &v2.ResourceId{ResourceType: "role"}
+
+	t.Run("legacy numeric offset token restarts the listing", func(t *testing.T) {
+		legacyToken := marshalPageToken(t, resourceID, "150")
+
+		_, lastID, err := parsePageToken(legacyToken, resourceID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if lastID != "" {
+			t.Errorf("lastID = %q, want empty (legacy offset token must restart, not be read as a sys_id cursor)", lastID)
+		}
+	})
+
+	t.Run("token with injected query condition fails loudly instead of restarting", func(t *testing.T) {
+		maliciousToken := marshalPageToken(t, resourceID, "abc^grantable=false")
+
+		_, _, err := parsePageToken(maliciousToken, resourceID)
+		if err == nil {
+			t.Fatalf("expected an error for a malformed token, got nil (silently restarting risks an infinite loop if this recurs)")
+		}
+	})
+
+	t.Run("real sys_id cursor passes through unchanged", func(t *testing.T) {
+		sysID := "cc6f85b5ebc31300a210a2505206fec0"
+		keysetToken := marshalPageToken(t, resourceID, sysID)
+
+		_, lastID, err := parsePageToken(keysetToken, resourceID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if lastID != sysID {
+			t.Errorf("lastID = %q, want %q", lastID, sysID)
+		}
+	})
+
+	t.Run("uppercase sys_id cursor is normalized to lowercase", func(t *testing.T) {
+		sysID := "CC6F85B5EBC31300A210A2505206FEC0"
+		keysetToken := marshalPageToken(t, resourceID, sysID)
+
+		_, lastID, err := parsePageToken(keysetToken, resourceID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "cc6f85b5ebc31300a210a2505206fec0"
+		if lastID != want {
+			t.Errorf("lastID = %q, want %q (ServiceNow's collation is case-insensitive; normalize for a stable cursor)", lastID, want)
+		}
+	})
+
+	t.Run("empty token (first page) passes through unchanged", func(t *testing.T) {
+		_, lastID, err := parsePageToken("", resourceID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if lastID != "" {
+			t.Errorf("lastID = %q, want empty", lastID)
+		}
+	})
+}

--- a/pkg/connector/helpers_test.go
+++ b/pkg/connector/helpers_test.go
@@ -29,24 +29,21 @@ func marshalPageToken(t *testing.T, resourceID *v2.ResourceId, checkpointedToken
 	return marshaled
 }
 
-// TestParsePageToken_TokenValidation covers the three shapes a checkpointed
+// TestParsePageToken_TokenValidation covers the two shapes a checkpointed
 // page token can take: (1) a real sys_id passes through as the seek
-// cursor, normalized to lowercase; (2) a legacy numeric offset token
-// silently restarts the listing instead of being read as a literal sys_id
-// cursor; (3) anything else fails loudly instead of silently restarting,
-// to avoid a possible infinite loop.
+// cursor, normalized to lowercase; (2) anything else -- including a
+// pre-keyset numeric offset token -- fails loudly instead of guessing,
+// since a wrong guess here means silently wrong pagination results, not
+// just a restart.
 func TestParsePageToken_TokenValidation(t *testing.T) {
 	resourceID := &v2.ResourceId{ResourceType: "role"}
 
-	t.Run("legacy numeric offset token restarts the listing", func(t *testing.T) {
+	t.Run("legacy numeric offset token fails loudly", func(t *testing.T) {
 		legacyToken := marshalPageToken(t, resourceID, "150")
 
-		_, lastID, err := parsePageToken(legacyToken, resourceID)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if lastID != "" {
-			t.Errorf("lastID = %q, want empty (legacy offset token must restart, not be read as a sys_id cursor)", lastID)
+		_, _, err := parsePageToken(legacyToken, resourceID)
+		if err == nil {
+			t.Fatalf("expected an error for a pre-keyset offset token, got nil")
 		}
 	})
 

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -33,15 +33,12 @@ func roleResource(role *servicenow.Role) (*v2.Resource, error) {
 		"role_id":   role.Id,
 	}
 
-	roleTraitOptions := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
-
 	resource, err := rs.NewRoleResource(
 		role.Name,
 		resourceTypeRole,
 		role.Id,
-		roleTraitOptions,
+		nil,
+		rs.WithResourceProfile(profile),
 	)
 
 	if err != nil {
@@ -52,16 +49,16 @@ func roleResource(role *servicenow.Role) (*v2.Resource, error) {
 }
 
 func (r *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
-	bag, offset, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeRole.Id})
+	bag, lastID, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeRole.Id})
 	if err != nil {
 		return nil, "", nil, err
 	}
 
 	roles, nextPageToken, err := r.client.GetRoles(
 		ctx,
-		servicenow.PaginationVars{
+		servicenow.KeysetPaginationVars{
 			Limit:  ResourcesPageSize,
-			Offset: offset,
+			LastID: lastID,
 		},
 	)
 	if err != nil {
@@ -107,7 +104,7 @@ func (r *roleResourceType) Entitlements(ctx context.Context, resource *v2.Resour
 }
 
 func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	bag, offset, err := parsePageToken(pt.Token, resource.Id)
+	bag, lastID, err := parsePageToken(pt.Token, resource.Id)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -126,11 +123,11 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 	case resourceTypeUser.Id:
 		usersToRoles, nextPageToken, err := r.client.GetUserToRole(
 			ctx,
-			"", // all users
+			"", // all users, domain-filtered when allowed-domains is set
 			resource.Id.Resource,
-			servicenow.PaginationVars{
+			servicenow.KeysetPaginationVars{
 				Limit:  ResourcesPageSize,
-				Offset: offset,
+				LastID: lastID,
 			},
 		)
 		if err != nil {
@@ -162,9 +159,9 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 			ctx,
 			"", // all groups
 			resource.Id.Resource,
-			servicenow.PaginationVars{
+			servicenow.KeysetPaginationVars{
 				Limit:  ResourcesPageSize,
-				Offset: offset,
+				LastID: lastID,
 			},
 		)
 		if err != nil {
@@ -221,7 +218,7 @@ func (r *roleResourceType) GrantToUser(ctx context.Context, l *zap.Logger, princ
 		ctx,
 		principal,
 		roleId,
-		servicenow.PaginationVars{Limit: 1},
+		servicenow.KeysetPaginationVars{Limit: 1},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("baton-servicenow: failed to get user roles for %s: %w", principal, err)
@@ -259,7 +256,7 @@ func (r *roleResourceType) GrantToGroup(ctx context.Context, l *zap.Logger, prin
 		ctx,
 		principal,
 		roleId,
-		servicenow.PaginationVars{Limit: 1},
+		servicenow.KeysetPaginationVars{Limit: 1},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("baton-servicenow: failed to get group roles for %s: %w", principal, err)
@@ -327,7 +324,7 @@ func (r *roleResourceType) RevokeFromUser(ctx context.Context, l *zap.Logger, pr
 		ctx,
 		principal.Id.Resource,
 		roleId,
-		servicenow.PaginationVars{Limit: 1},
+		servicenow.KeysetPaginationVars{Limit: 1},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("baton-servicenow: failed to get user roles for %s: %w", principal.Id.Resource, err)
@@ -365,7 +362,7 @@ func (r *roleResourceType) RevokeFromGroup(ctx context.Context, l *zap.Logger, p
 		ctx,
 		principal.Id.Resource,
 		roleId,
-		servicenow.PaginationVars{Limit: 1},
+		servicenow.KeysetPaginationVars{Limit: 1},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("baton-servicenow: failed to get group roles for %s: %w", principal.Id.Resource, err)

--- a/pkg/connector/role_test.go
+++ b/pkg/connector/role_test.go
@@ -1,0 +1,30 @@
+package connector
+
+import (
+	"testing"
+
+	"github.com/conductorone/baton-servicenow/pkg/servicenow"
+)
+
+// TestRoleResource_ProfileSurfacesOnResource guards against a regression
+// from moving the role profile from a RoleTrait option to a resource-level
+// option: the resource itself must still carry the profile fields.
+func TestRoleResource_ProfileSurfacesOnResource(t *testing.T) {
+	role := &servicenow.Role{
+		BaseResource: servicenow.BaseResource{Id: "role-1"},
+		Name:         "admin",
+	}
+
+	resource, err := roleResource(role)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	profile := resource.GetProfile().AsMap()
+	if got := profile["role_name"]; got != "admin" {
+		t.Errorf("profile[role_name] = %v, want %q", got, "admin")
+	}
+	if got := profile["role_id"]; got != "role-1" {
+		t.Errorf("profile[role_id] = %v, want %q", got, "role-1")
+	}
+}

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -36,16 +36,16 @@ func userResource(user *servicenow.User) (*v2.Resource, error) {
 		profile[k] = v
 	}
 
-	// Map ServiceNow active status to Baton user status
-	var userStatus v2.UserTrait_Status_Status
+	// Map ServiceNow active status to Baton resource status
+	var userStatus v2.Status_ResourceStatus
 	switch user.Active {
 	case "true", "True", "TRUE", "1":
-		userStatus = v2.UserTrait_Status_STATUS_ENABLED
+		userStatus = v2.Status_RESOURCE_STATUS_ENABLED
 	case "false", "False", "FALSE", "0":
-		userStatus = v2.UserTrait_Status_STATUS_DISABLED
+		userStatus = v2.Status_RESOURCE_STATUS_DISABLED
 	default:
 		// Default to disabled for unknown values to be safe
-		userStatus = v2.UserTrait_Status_STATUS_DISABLED
+		userStatus = v2.Status_RESOURCE_STATUS_DISABLED
 	}
 
 	userTraitOptions := []rs.UserTraitOption{
@@ -58,7 +58,7 @@ func userResource(user *servicenow.User) (*v2.Resource, error) {
 		user.Id,
 		userTraitOptions,
 		rs.WithResourceProfile(profile),
-		rs.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
+		rs.WithResourceStatus(userStatus, ""),
 	)
 
 	if err != nil {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -50,8 +50,6 @@ func userResource(user *servicenow.User) (*v2.Resource, error) {
 
 	userTraitOptions := []rs.UserTraitOption{
 		rs.WithEmail(user.Email, true),
-		rs.WithUserProfile(profile),
-		rs.WithStatus(userStatus),
 	}
 
 	resource, err := rs.NewUserResource(
@@ -59,6 +57,8 @@ func userResource(user *servicenow.User) (*v2.Resource, error) {
 		resourceTypeUser,
 		user.Id,
 		userTraitOptions,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 	)
 
 	if err != nil {
@@ -69,16 +69,16 @@ func userResource(user *servicenow.User) (*v2.Resource, error) {
 }
 
 func (u *userResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
-	bag, offset, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeUser.Id})
+	bag, lastID, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeUser.Id})
 	if err != nil {
 		return nil, "", nil, err
 	}
 
 	users, nextPageToken, err := u.client.GetUsers(
 		ctx,
-		servicenow.PaginationVars{
+		servicenow.KeysetPaginationVars{
 			Limit:  ResourcesPageSize,
-			Offset: offset,
+			LastID: lastID,
 		},
 	)
 	if err != nil {

--- a/pkg/connector/user_test.go
+++ b/pkg/connector/user_test.go
@@ -1,0 +1,50 @@
+package connector
+
+import (
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-servicenow/pkg/servicenow"
+)
+
+// TestUserResource_StatusSurfacesOnResource guards against a regression from
+// switching the enabled/disabled status from a UserTrait option to a
+// resource-level option: the resource itself, not just the trait, must still
+// carry the correct enabled/disabled status for every Active value ServiceNow
+// can send.
+func TestUserResource_StatusSurfacesOnResource(t *testing.T) {
+	tests := []struct {
+		name   string
+		active string
+		want   v2.Status_ResourceStatus
+	}{
+		{"true", "true", v2.Status_RESOURCE_STATUS_ENABLED},
+		{"True", "True", v2.Status_RESOURCE_STATUS_ENABLED},
+		{"1", "1", v2.Status_RESOURCE_STATUS_ENABLED},
+		{"false", "false", v2.Status_RESOURCE_STATUS_DISABLED},
+		{"False", "False", v2.Status_RESOURCE_STATUS_DISABLED},
+		{"0", "0", v2.Status_RESOURCE_STATUS_DISABLED},
+		{"unknown value defaults to disabled", "unexpected", v2.Status_RESOURCE_STATUS_DISABLED},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			user := &servicenow.User{
+				BaseResource: servicenow.BaseResource{Id: "user-1"},
+				UserName:     "jdoe",
+				Email:        "jdoe@example.com",
+				Active:       tc.active,
+			}
+
+			resource, err := userResource(user)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got := resource.GetStatus().GetStatus()
+			if got != tc.want {
+				t.Errorf("resource status = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -86,16 +86,8 @@ type SingleResponse[T any] struct {
 
 type IDResponse = SingleResponse[BaseResource]
 type UserResponse = SingleResponse[User]
-type UsersResponse = ListResponse[User]
-type RolesResponse = ListResponse[Role]
-type GroupsResponse = ListResponse[Group]
 type GroupResponse = SingleResponse[Group]
-type GroupMembersResponse = ListResponse[GroupMember]
-type UserRolesResponse = SingleResponse[UserRoles]
-type UserToRoleResponse ListResponse[UserToRole]
-type GroupToRoleResponse ListResponse[GroupToRole]
 type CatalogsResponse = ListResponse[Catalog]
-type CategoriesResponse = ListResponse[Category]
 type CatalogItemsResponse = ListResponse[CatalogItem]
 type CatalogItemResponse = SingleResponse[CatalogItem]
 type CatalogItemVariablesResponse = ListResponse[CatalogItemVariable]
@@ -175,25 +167,27 @@ func (c *Client) apiURL(pattern string, args ...any) string {
 	return expanded
 }
 
-// Table `sys_user` (Users).
-func (c *Client) GetUsers(ctx context.Context, paginationVars PaginationVars) ([]User, string, error) {
-	var usersResponse UsersResponse
-
-	reqOpts := filterToReqOptions(prepareUserFilters(c.AllowedDomains, c.CustomUserFields))
-	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
-
-	nextPage, err := c.get(
-		ctx,
-		c.apiURL(UsersBaseUrl, c.deployment),
-		&usersResponse,
-		reqOpts...,
-	)
-
-	if err != nil {
+// getKeysetPage runs one keyset-paginated Table API GET and derives the
+// next seek token from the response. Uses c.getKeyset, not c.get: keyset
+// callers compute their own token via nextKeysetToken and don't need
+// doRequest's legacy Link-header token.
+func getKeysetPage[T any](ctx context.Context, c *Client, url string, reqOpts []ReqOpt, idFn func(T) string) ([]T, string, error) {
+	var resp ListResponse[T]
+	if err := c.getKeyset(ctx, url, &resp, reqOpts...); err != nil {
 		return nil, "", err
 	}
+	return resp.Result, nextKeysetToken(resp.Result, idFn), nil
+}
 
-	return usersResponse.Result, nextPage, nil
+// Table sys_user (Users). GetUsers always enumerates -- there's no
+// per-user provisioning variant -- so the domain filter and its page-size
+// cap (domainFilteredPageSize) always apply when AllowedDomains is
+// configured.
+func (c *Client) GetUsers(ctx context.Context, paginationVars KeysetPaginationVars) ([]User, string, error) {
+	paginationVars = cappedForDomainFilter("", c.AllowedDomains, paginationVars)
+	reqOpts := buildKeysetReqOptions(prepareUserFilters(c.AllowedDomains, c.CustomUserFields), &paginationVars)
+
+	return getKeysetPage(ctx, c, c.apiURL(UsersBaseUrl, c.deployment), reqOpts, func(u User) string { return u.Id })
 }
 
 func (c *Client) GetUser(ctx context.Context, userId string) (*User, error) {
@@ -213,24 +207,11 @@ func (c *Client) GetUser(ctx context.Context, userId string) (*User, error) {
 	return &userResponse.Result, nil
 }
 
-// Table `sys_user_group` (Groups).
-func (c *Client) GetGroups(ctx context.Context, paginationVars PaginationVars, groupIDs []string) ([]Group, string, error) {
-	var groupsResponse GroupsResponse
+// Table sys_user_group (Groups).
+func (c *Client) GetGroups(ctx context.Context, paginationVars KeysetPaginationVars, groupIDs []string) ([]Group, string, error) {
+	reqOpts := buildKeysetReqOptions(prepareGroupFilters(groupIDs), &paginationVars)
 
-	reqOpts := filterToReqOptions(prepareGroupFilters(groupIDs))
-	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
-	nextPageToken, err := c.get(
-		ctx,
-		c.apiURL(GroupsBaseUrl, c.deployment),
-		&groupsResponse,
-		reqOpts...,
-	)
-
-	if err != nil {
-		return nil, "", err
-	}
-
-	return groupsResponse.Result, nextPageToken, nil
+	return getKeysetPage(ctx, c, c.apiURL(GroupsBaseUrl, c.deployment), reqOpts, func(g Group) string { return g.Id })
 }
 
 func (c *Client) GetGroup(ctx context.Context, groupId string) (*Group, error) {
@@ -250,25 +231,14 @@ func (c *Client) GetGroup(ctx context.Context, groupId string) (*Group, error) {
 	return &groupResponse.Result, nil
 }
 
-// Table `sys_user_grmember` (Group Members).
-func (c *Client) GetUserToGroup(ctx context.Context, userId string, groupId string, paginationVars PaginationVars) ([]GroupMember, string, error) {
-	var groupMembersResponse GroupMembersResponse
+// Table sys_user_grmember (Group Members). When userId is empty
+// (enumeration), results are scoped to allowed-domains via user.email and
+// the page size is capped (see domainFilteredPageSize).
+func (c *Client) GetUserToGroup(ctx context.Context, userId string, groupId string, paginationVars KeysetPaginationVars) ([]GroupMember, string, error) {
+	paginationVars = cappedForDomainFilter(userId, c.AllowedDomains, paginationVars)
+	reqOpts := buildKeysetReqOptions(prepareUserToGroupFilter(userId, groupId, c.AllowedDomains), &paginationVars)
 
-	reqOpts := filterToReqOptions(prepareUserToGroupFilter(userId, groupId))
-	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
-
-	nextPageToken, err := c.get(
-		ctx,
-		c.apiURL(GroupMembersBaseUrl, c.deployment),
-		&groupMembersResponse,
-		reqOpts...,
-	)
-
-	if err != nil {
-		return nil, "", err
-	}
-
-	return groupMembersResponse.Result, nextPageToken, nil
+	return getKeysetPage(ctx, c, c.apiURL(GroupMembersBaseUrl, c.deployment), reqOpts, func(m GroupMember) string { return m.Id })
 }
 
 func (c *Client) AddUserToGroup(ctx context.Context, record GroupMemberPayload) error {
@@ -289,47 +259,21 @@ func (c *Client) RemoveUserFromGroup(ctx context.Context, id string) error {
 	)
 }
 
-// Table `sys_user_role` (Roles).
-func (c *Client) GetRoles(ctx context.Context, paginationVars PaginationVars) ([]Role, string, error) {
-	var rolesResponse RolesResponse
+// Table sys_user_role (Roles).
+func (c *Client) GetRoles(ctx context.Context, paginationVars KeysetPaginationVars) ([]Role, string, error) {
+	reqOpts := buildKeysetReqOptions(prepareRoleFilters(), &paginationVars)
 
-	paginationVars.Limit++
-	reqOpts := filterToReqOptions(prepareRoleFilters())
-	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
-
-	nextPageToken, err := c.get(
-		ctx,
-		c.apiURL(RolesBaseUrl, c.deployment),
-		&rolesResponse,
-		reqOpts...,
-	)
-
-	if err != nil {
-		return nil, "", err
-	}
-
-	return rolesResponse.Result, nextPageToken, nil
+	return getKeysetPage(ctx, c, c.apiURL(RolesBaseUrl, c.deployment), reqOpts, func(r Role) string { return r.Id })
 }
 
-// Table `sys_user_has_role` (User to Role).
-func (c *Client) GetUserToRole(ctx context.Context, userId string, roleId string, paginationVars PaginationVars) ([]UserToRole, string, error) {
-	var userToRoleResponse UserToRoleResponse
+// Table sys_user_has_role (User to Role). When userId is empty
+// (enumeration), results are scoped to allowed-domains via user.email and
+// the page size is capped (see domainFilteredPageSize).
+func (c *Client) GetUserToRole(ctx context.Context, userId string, roleId string, paginationVars KeysetPaginationVars) ([]UserToRole, string, error) {
+	paginationVars = cappedForDomainFilter(userId, c.AllowedDomains, paginationVars)
+	reqOpts := buildKeysetReqOptions(prepareUserToRoleFilter(userId, roleId, c.AllowedDomains), &paginationVars)
 
-	reqOpts := filterToReqOptions(prepareUserToRoleFilter(userId, roleId))
-	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
-
-	nextPageToken, err := c.get(
-		ctx,
-		c.apiURL(UserRolesBaseUrl, c.deployment),
-		&userToRoleResponse,
-		reqOpts...,
-	)
-
-	if err != nil {
-		return nil, "", err
-	}
-
-	return userToRoleResponse.Result, nextPageToken, nil
+	return getKeysetPage(ctx, c, c.apiURL(UserRolesBaseUrl, c.deployment), reqOpts, func(r UserToRole) string { return r.Id })
 }
 
 func (c *Client) GrantRoleToUser(ctx context.Context, record UserToRolePayload) error {
@@ -350,24 +294,12 @@ func (c *Client) RevokeRoleFromUser(ctx context.Context, id string) error {
 	)
 }
 
-// Table `sys_group_has_role` (Group to Role).
-func (c *Client) GetGroupToRole(ctx context.Context, groupId string, roleId string, paginationVars PaginationVars) ([]GroupToRole, string, error) {
-	var groupToRoleResponse GroupToRoleResponse
+// Table sys_group_has_role (Group to Role). No domain filter -- groups
+// don't have an email to scope by.
+func (c *Client) GetGroupToRole(ctx context.Context, groupId string, roleId string, paginationVars KeysetPaginationVars) ([]GroupToRole, string, error) {
+	reqOpts := buildKeysetReqOptions(prepareGroupToRoleFilter(groupId, roleId), &paginationVars)
 
-	reqOpts := filterToReqOptions(prepareGroupToRoleFilter(groupId, roleId))
-	reqOpts = append(reqOpts, paginationVarsToReqOptions(&paginationVars)...)
-	nextPageToken, err := c.get(
-		ctx,
-		c.apiURL(GroupRolesBaseUrl, c.deployment),
-		&groupToRoleResponse,
-		reqOpts...,
-	)
-
-	if err != nil {
-		return nil, "", err
-	}
-
-	return groupToRoleResponse.Result, nextPageToken, nil
+	return getKeysetPage(ctx, c, c.apiURL(GroupRolesBaseUrl, c.deployment), reqOpts, func(r GroupToRole) string { return r.Id })
 }
 
 func (c *Client) GrantRoleToGroup(ctx context.Context, record GroupToRolePayload) error {
@@ -390,6 +322,19 @@ func (c *Client) RevokeRoleFromGroup(ctx context.Context, id string) error {
 
 func (c *Client) get(ctx context.Context, urlAddress string, resourceResponse interface{}, reqOptions ...ReqOpt) (string, error) {
 	return c.doRequestWithRetry(
+		ctx,
+		urlAddress,
+		http.MethodGet,
+		nil,
+		&resourceResponse,
+		reqOptions...,
+	)
+}
+
+// getKeyset is like get but for keyset-paginated callers: it never computes
+// the legacy Link-header/X-Total-Count token, so it can't fail because of it.
+func (c *Client) getKeyset(ctx context.Context, urlAddress string, resourceResponse interface{}, reqOptions ...ReqOpt) error {
+	return c.doRequestWithRetryKeyset(
 		ctx,
 		urlAddress,
 		http.MethodGet,
@@ -484,13 +429,37 @@ func handleStatusCode(statusCode int) codes.Code {
 	return codes.OK
 }
 
+// doRequest performs the request, decodes a successful JSON body into
+// resourceResponse, and returns the legacy Link-header/X-Total-Count
+// offset-pagination token used by Service Catalog/ticketing callers. Keyset
+// callers use doRequestKeyset instead.
 func (c *Client) doRequest(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (string, error) {
+	header, err := c.doHTTPRequest(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
+	if err != nil {
+		return "", err
+	}
+	return legacyOffsetToken(header)
+}
+
+// doRequestKeyset is doRequest without the legacy Link-header/X-Total-Count
+// token computation. Keyset callers derive their own token from the decoded
+// body (nextKeysetToken), so a malformed Link header or non-numeric
+// sysparm_offset must not discard an otherwise successfully decoded page.
+func (c *Client) doRequestKeyset(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) error {
+	_, err := c.doHTTPRequest(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
+	return err
+}
+
+// doHTTPRequest sends the request and, for non-DELETE methods, decodes a
+// successful JSON body into resourceResponse. Returns only the response
+// headers, for callers that need to read pagination headers afterward.
+func (c *Client) doHTTPRequest(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (http.Header, error) {
 	var body io.Reader
 
 	if data != nil {
 		jsonBody, err := json.Marshal(data)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
 		body = bytes.NewBuffer(jsonBody)
@@ -498,7 +467,7 @@ func (c *Client) doRequest(ctx context.Context, urlAddress string, method string
 
 	req, err := http.NewRequestWithContext(ctx, method, urlAddress, body)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// Set default value
@@ -522,32 +491,39 @@ func (c *Client) doRequest(ctx context.Context, urlAddress string, method string
 		defer rawResponse.Body.Close()
 	}
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if rawResponse.StatusCode < 0 || rawResponse.StatusCode > math.MaxUint32 {
-		return "", errors.New("status code is out of range for uint32")
+		return nil, errors.New("status code is out of range for uint32")
 	}
 
 	if rawResponse.StatusCode >= 300 {
 		respBody, _ := io.ReadAll(rawResponse.Body)
-		return "", status.Errorf(handleStatusCode(rawResponse.StatusCode), "baton-servicenow: request failed with status %d: %s", rawResponse.StatusCode, string(respBody))
+		return nil, status.Errorf(handleStatusCode(rawResponse.StatusCode), "baton-servicenow: request failed with status %d: %s", rawResponse.StatusCode, string(respBody))
 	}
 
 	if method != http.MethodDelete {
 		if err := json.NewDecoder(rawResponse.Body).Decode(&resourceResponse); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 
-	totalCountHeader := rawResponse.Header.Get("X-Total-Count")
+	return rawResponse.Header, nil
+}
+
+// legacyOffsetToken computes the Service Catalog/ticketing offset-pagination
+// token from the Link/X-Total-Count headers of an already-completed
+// request. Only doRequest's (non-keyset) callers use this.
+func legacyOffsetToken(header http.Header) (string, error) {
+	totalCountHeader := header.Get("X-Total-Count")
 	totalCount, err := ConvertPageToken(totalCountHeader)
 	if err != nil {
 		return "", err
 	}
 
 	var pageToken string
-	pagingLinks := linkheader.Parse(rawResponse.Header.Get("Link"))
+	pagingLinks := linkheader.Parse(header.Get("Link"))
 	for _, link := range pagingLinks {
 		if link.Rel == "next" {
 			nextPageUrl, err := url.Parse(link.URL)
@@ -577,16 +553,35 @@ const (
 // doRequestWithRetry wraps doRequest with a small retry loop for transient 401 responses.
 // On each 401 it logs the ServiceNow error body and waits an increasing delay before retrying.
 func (c *Client) doRequestWithRetry(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (string, error) {
+	return withAuthRetry(ctx, urlAddress, method, func() (string, error) {
+		return c.doRequest(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
+	})
+}
+
+// doRequestWithRetryKeyset is doRequestWithRetry for keyset callers, routed
+// through doRequestKeyset instead of doRequest so a legacy-pagination-header
+// hiccup can't fail an otherwise successfully decoded page.
+func (c *Client) doRequestWithRetryKeyset(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) error {
+	_, err := withAuthRetry(ctx, urlAddress, method, func() (string, error) {
+		return "", c.doRequestKeyset(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
+	})
+	return err
+}
+
+// withAuthRetry retries attempt on transient 401 responses, logging the
+// retry/backoff around it. attempt returns whatever pagination token its
+// underlying request produces (keyset callers always pass "").
+func withAuthRetry(ctx context.Context, urlAddress string, method string, attempt func() (string, error)) (string, error) {
 	l := ctxzap.Extract(ctx)
 
 	var lastErr error
-	for attempt := 1; attempt <= maxAuthRetries+1; attempt++ {
-		if attempt > 1 {
-			delay := time.Duration(attempt-1) * authRetryBaseWait
+	for try := 1; try <= maxAuthRetries+1; try++ {
+		if try > 1 {
+			delay := time.Duration(try-1) * authRetryBaseWait
 			l.Debug("baton-servicenow: retrying request after 401",
 				zap.String("url", urlAddress),
 				zap.String("method", method),
-				zap.Int("attempt", attempt),
+				zap.Int("attempt", try),
 				zap.Int("max_attempts", maxAuthRetries+1),
 				zap.Duration("delay", delay),
 			)
@@ -597,13 +592,13 @@ func (c *Client) doRequestWithRetry(ctx context.Context, urlAddress string, meth
 			}
 		}
 
-		pageToken, err := c.doRequest(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
+		pageToken, err := attempt()
 		if err == nil {
-			if attempt > 1 {
+			if try > 1 {
 				l.Debug("baton-servicenow: request succeeded after retry",
 					zap.String("url", urlAddress),
 					zap.String("method", method),
-					zap.Int("attempt", attempt),
+					zap.Int("attempt", try),
 				)
 			}
 			return pageToken, nil
@@ -616,7 +611,7 @@ func (c *Client) doRequestWithRetry(ctx context.Context, urlAddress string, meth
 		l.Debug("baton-servicenow: received 401 unauthorized",
 			zap.String("url", urlAddress),
 			zap.String("method", method),
-			zap.Int("attempt", attempt),
+			zap.Int("attempt", try),
 			zap.Int("max_attempts", maxAuthRetries+1),
 			zap.Error(err),
 		)

--- a/pkg/servicenow/client_test.go
+++ b/pkg/servicenow/client_test.go
@@ -1,0 +1,151 @@
+package servicenow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestGetRoles_DoesNotTruncateOnShortNonEmptyPage guards against treating a
+// short-but-nonempty page as the last one. ServiceNow doesn't reliably
+// honor sysparm_limit's exact row count, so terminating on "page shorter
+// than requested" silently truncates the listing -- only a genuinely empty
+// page may end pagination.
+func TestGetRoles_DoesNotTruncateOnShortNonEmptyPage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		isSeeking := strings.Contains(r.URL.Query().Get("sysparm_query"), "sys_id>")
+
+		// Page 1: full. Page 2: ServiceNow under-delivers (3 of 50
+		// requested) even though more data remains -- must NOT read as
+		// last page. Page 3: genuinely empty, the only valid termination
+		// signal.
+		var n int
+		switch {
+		case !isSeeking:
+			n = 50
+		case strings.Contains(r.URL.Query().Get("sysparm_query"), "role-049"):
+			n = 3
+		default:
+			n = 0
+		}
+
+		roles := make([]Role, n)
+		for i := range roles {
+			roles[i] = Role{BaseResource: BaseResource{Id: fmt.Sprintf("role-%03d", i)}}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(ListResponse[Role]{Result: roles}); err != nil {
+			// t.Fatalf must not be called from the handler's goroutine --
+			// it would only stop this goroutine mid-response and surface a
+			// confusing secondary failure in the test itself.
+			t.Errorf("failed to encode test response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.Client(), "Basic dGVzdDp0ZXN0", "dev0", nil, nil, nil, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+
+	page1, next1, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50})
+	if err != nil {
+		t.Fatalf("unexpected error on page 1: %v", err)
+	}
+	if len(page1) != 50 {
+		t.Errorf("page1 len = %d, want 50", len(page1))
+	}
+	if next1 == "" {
+		t.Fatalf("expected a non-empty next token after a full page")
+	}
+
+	page2, next2, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50, LastID: next1})
+	if err != nil {
+		t.Fatalf("unexpected error on page 2: %v", err)
+	}
+	if len(page2) != 3 {
+		t.Errorf("page2 len = %d, want 3", len(page2))
+	}
+	if next2 == "" {
+		t.Fatalf("pagination stopped after a short-but-nonempty page (3 rows) while more rows remained")
+	}
+
+	page3, next3, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50, LastID: next2})
+	if err != nil {
+		t.Fatalf("unexpected error on page 3: %v", err)
+	}
+	if len(page3) != 0 {
+		t.Errorf("page3 len = %d, want 0", len(page3))
+	}
+	if next3 != "" {
+		t.Errorf("expected pagination to terminate after a genuinely empty page, got token %q", next3)
+	}
+}
+
+// TestGetRoles_IgnoresMalformedLegacyPaginationHeaders guards against a
+// keyset page failing over the unrelated legacy Link-header/X-Total-Count
+// computation, which keyset callers never read (see doRequestKeyset in
+// client.go).
+func TestGetRoles_IgnoresMalformedLegacyPaginationHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// doRequest's legacy pagination-token logic would fail parsing this
+		// as an int; doRequestKeyset must never even attempt to.
+		w.Header().Set("X-Total-Count", "not-a-number")
+		w.Header().Set("Content-Type", "application/json")
+
+		roles := []Role{{BaseResource: BaseResource{Id: "role-000"}}}
+		if err := json.NewEncoder(w).Encode(ListResponse[Role]{Result: roles}); err != nil {
+			t.Errorf("failed to encode test response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.Client(), "Basic dGVzdDp0ZXN0", "dev0", nil, nil, nil, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+
+	roles, _, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50})
+	if err != nil {
+		t.Fatalf("unexpected error: %v (a malformed legacy pagination header must not fail a keyset page fetch)", err)
+	}
+	if len(roles) != 1 || roles[0].Id != "role-000" {
+		t.Errorf("roles = %+v, want a single role-000", roles)
+	}
+}
+
+// TestGetUsers_CapsPageSizeWhenDomainFilterApplies covers GetUsers
+// specifically: it always enumerates (no per-user provisioning variant),
+// so the domain filter's page-size cap always applies when AllowedDomains
+// is configured.
+func TestGetUsers_CapsPageSizeWhenDomainFilterApplies(t *testing.T) {
+	var gotLimit string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotLimit = r.URL.Query().Get("sysparm_limit")
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(ListResponse[User]{Result: nil}); err != nil {
+			t.Errorf("failed to encode test response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.Client(), "Basic dGVzdDp0ZXN0", "dev0", nil, []string{"draftkings.com"}, nil, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+
+	_, _, err = client.GetUsers(context.Background(), KeysetPaginationVars{Limit: 200})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := fmt.Sprintf("%d", domainFilteredPageSize)
+	if gotLimit != want {
+		t.Errorf("sysparm_limit sent = %q, want %q (AllowedDomains configured must cap the page size)", gotLimit, want)
+	}
+}

--- a/pkg/servicenow/model.go
+++ b/pkg/servicenow/model.go
@@ -110,12 +110,6 @@ type GroupToRolePayload struct {
 	Role  string `json:"role"`
 }
 
-type UserRoles struct {
-	UserName  string   `json:"user_name"`
-	FromRole  []string `json:"from_role"`
-	FromGroup []string `json:"from_group"`
-}
-
 // TODO(lauren) remove unecessary fields.
 // Service Catalog request models.
 type ResourceRefLink struct {

--- a/pkg/servicenow/request.go
+++ b/pkg/servicenow/request.go
@@ -66,6 +66,20 @@ func WithQuery(query string) ReqOpt {
 	return emptyOpt
 }
 
+// WithQueryAppend AND-appends extra onto whatever sysparm_query is already set on the request.
+func WithQueryAppend(extra string) ReqOpt {
+	if extra == "" {
+		return emptyOpt
+	}
+	return func(req *http.Request) {
+		merged := extra
+		if existing := req.URL.Query().Get("sysparm_query"); existing != "" {
+			merged = existing + "^" + extra
+		}
+		WithQueryParam("sysparm_query", merged)(req)
+	}
+}
+
 func WithFields(fields ...string) ReqOpt {
 	if len(fields) != 0 {
 		return WithQueryParam("sysparm_fields", strings.Join(fields, ","))
@@ -77,9 +91,82 @@ func WithIncludeExternalRefLink() ReqOpt {
 	return WithQueryParam("sysparm_exclude_reference_link", "false")
 }
 
+// WithNoCount skips ServiceNow's X-Total-Count computation (a COUNT(*) over
+// the whole filtered set). Keyset termination doesn't need it -- it only
+// checks for an empty page (see nextKeysetToken).
+func WithNoCount() ReqOpt {
+	return WithQueryParam("sysparm_no_count", "true")
+}
+
 type PaginationVars struct {
 	Limit  int
 	Offset int
+}
+
+// KeysetPaginationVars carries seek/keyset pagination state for Table API
+// listings ordered by sys_id. Used by identity and membership endpoints
+// (users, roles, groups, membership) instead of sysparm_offset, whose
+// deep-offset requests degrade on large tables. Service Catalog/ticketing
+// endpoints keep using PaginationVars/WithOffset.
+type KeysetPaginationVars struct {
+	Limit  int
+	LastID string
+}
+
+// domainFilteredPageSize caps the page size for enumeration calls that add
+// the allowed-domains dot-walk filter (user.emailENDSWITH@domain). ENDSWITH
+// can't use the sys_id index, so a bigger page means more rows ServiceNow
+// has to scan before it can respond.
+const domainFilteredPageSize = 50
+
+// cappedForDomainFilter caps vars.Limit to domainFilteredPageSize when the
+// domain filter applies (userId=="" and allowed-domains configured);
+// otherwise returns vars unchanged.
+func cappedForDomainFilter(userId string, domains []string, vars KeysetPaginationVars) KeysetPaginationVars {
+	if userId == "" && len(domains) > 0 && vars.Limit > domainFilteredPageSize {
+		vars.Limit = domainFilteredPageSize
+	}
+	return vars
+}
+
+// keysetPaginationVarsToReqOptions sets sysparm_limit, appends the sys_id
+// seek condition onto sysparm_query (must run after filterToReqOptions),
+// and disables X-Total-Count via WithNoCount.
+func keysetPaginationVarsToReqOptions(vars *KeysetPaginationVars) []ReqOpt {
+	reqOpts := make([]ReqOpt, 0, 3)
+	reqOpts = append(reqOpts, WithPageLimit(vars.Limit))
+	reqOpts = append(reqOpts, WithQueryAppend(keysetCursorFragment(vars.LastID)))
+	reqOpts = append(reqOpts, WithNoCount())
+	return reqOpts
+}
+
+// buildKeysetReqOptions composes a filter with keyset pagination in the
+// only valid order: the seek condition must be appended after the filter
+// sets sysparm_query.
+func buildKeysetReqOptions(filterVars *FilterVars, keysetVars *KeysetPaginationVars) []ReqOpt {
+	reqOpts := filterToReqOptions(filterVars)
+	return append(reqOpts, keysetPaginationVarsToReqOptions(keysetVars)...)
+}
+
+// keysetCursorFragment builds the sysparm_query fragment that seeks past
+// lastID. ORDERBYsys_id is required on every page, including the first,
+// so the cursor stays consistent with how the page is ordered.
+func keysetCursorFragment(lastID string) string {
+	if lastID != "" {
+		return fmt.Sprintf("sys_id>%s^ORDERBYsys_id", lastID)
+	}
+	return "ORDERBYsys_id"
+}
+
+// nextKeysetToken derives the next seek token from a keyset page.
+// Termination is decided solely by an empty page, never by len(items) <
+// limit: ServiceNow doesn't always return exactly the requested row count,
+// so a short-but-nonempty page must not be treated as the last one.
+func nextKeysetToken[T any](items []T, idFn func(T) string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	return idFn(items[len(items)-1])
 }
 
 type FilterVars struct {
@@ -88,18 +175,23 @@ type FilterVars struct {
 	UserId string
 }
 
-func prepareUserFilters(domains []string, customFields []string) *FilterVars {
+// buildDomainQuery builds an OR'd ENDSWITH condition over emailField for
+// each domain (e.g. "emailENDSWITH@a.com^ORemailENDSWITH@b.com"). Returns
+// "" when domains is empty.
+func buildDomainQuery(emailField string, domains []string) string {
 	var queries []string
 
 	for _, domain := range domains {
 		d := strings.TrimSpace(strings.ToLower(domain))
 		if d != "" {
-			queries = append(queries, fmt.Sprintf("emailENDSWITH@%s", d))
+			queries = append(queries, fmt.Sprintf("%sENDSWITH@%s", emailField, d))
 		}
 	}
 
-	combined := strings.Join(queries, "^OR")
+	return strings.Join(queries, "^OR")
+}
 
+func prepareUserFilters(domains []string, customFields []string) *FilterVars {
 	fields := UserFields
 	for _, f := range customFields {
 		if strings.HasPrefix(f, "u_") {
@@ -109,7 +201,7 @@ func prepareUserFilters(domains []string, customFields []string) *FilterVars {
 
 	return &FilterVars{
 		Fields: fields,
-		Query:  combined,
+		Query:  buildDomainQuery("email", domains),
 	}
 }
 
@@ -133,18 +225,24 @@ func prepareGroupFilters(ids []string) *FilterVars {
 	}
 }
 
-func prepareUserToGroupFilter(userId string, groupId string) *FilterVars {
-	var query string
+// prepareUserToGroupFilter builds the sys_user_grmember filter. When userId
+// is empty (enumerating all members, not checking one user for
+// provisioning), it also scopes user.email to the allowed domains, so
+// group grants stay consistent with which users actually get synced.
+func prepareUserToGroupFilter(userId string, groupId string, domains []string) *FilterVars {
+	var conditions []string
 
 	if userId != "" {
-		query = fmt.Sprintf("user=%s", userId)
+		conditions = append(conditions, fmt.Sprintf("user=%s", userId))
 	}
 
 	if groupId != "" {
-		if query != "" {
-			query = fmt.Sprintf("%s^group=%s", query, groupId)
-		} else {
-			query = fmt.Sprintf("group=%s", groupId)
+		conditions = append(conditions, fmt.Sprintf("group=%s", groupId))
+	}
+
+	if userId == "" {
+		if domainQuery := buildDomainQuery("user.email", domains); domainQuery != "" {
+			conditions = append(conditions, domainQuery)
 		}
 	}
 
@@ -152,21 +250,26 @@ func prepareUserToGroupFilter(userId string, groupId string) *FilterVars {
 		Fields: []string{
 			"sys_id", "user", "group",
 		},
-		Query: query,
+		Query: strings.Join(conditions, "^"),
 	}
 }
 
-func prepareUserToRoleFilter(userId string, roleId string) *FilterVars {
-	var query string
+// prepareUserToRoleFilter builds the sys_user_has_role filter. See
+// prepareUserToGroupFilter for why the domain filter is gated on userId=="".
+func prepareUserToRoleFilter(userId string, roleId string, domains []string) *FilterVars {
+	var conditions []string
+
 	if userId != "" {
-		query = fmt.Sprintf("user=%s", userId)
+		conditions = append(conditions, fmt.Sprintf("user=%s", userId))
 	}
 
 	if roleId != "" {
-		if query != "" {
-			query = fmt.Sprintf("%s^role=%s", query, roleId)
-		} else {
-			query = fmt.Sprintf("role=%s", roleId)
+		conditions = append(conditions, fmt.Sprintf("role=%s", roleId))
+	}
+
+	if userId == "" {
+		if domainQuery := buildDomainQuery("user.email", domains); domainQuery != "" {
+			conditions = append(conditions, domainQuery)
 		}
 	}
 
@@ -174,7 +277,7 @@ func prepareUserToRoleFilter(userId string, roleId string) *FilterVars {
 		Fields: []string{
 			"sys_id", "user", "role", "inherited",
 		},
-		Query: query,
+		Query: strings.Join(conditions, "^"),
 	}
 }
 

--- a/pkg/servicenow/request_test.go
+++ b/pkg/servicenow/request_test.go
@@ -1,0 +1,326 @@
+package servicenow
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func newTestRequest(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.service-now.com/api/now/table/sys_user", nil)
+	if err != nil {
+		t.Fatalf("unexpected error building request: %v", err)
+	}
+	return req
+}
+
+func applyReqOpts(req *http.Request, opts ...ReqOpt) {
+	for _, o := range opts {
+		o(req)
+	}
+}
+
+func TestBuildDomainQuery(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   string
+		domains []string
+		want    string
+	}{
+		{
+			name:    "multiple domains are OR'd",
+			field:   "user.email",
+			domains: []string{"draftkings.com", "dk.com"},
+			want:    "user.emailENDSWITH@draftkings.com^ORuser.emailENDSWITH@dk.com",
+		},
+		{
+			name:    "single domain",
+			field:   "email",
+			domains: []string{"a.com"},
+			want:    "emailENDSWITH@a.com",
+		},
+		{
+			name:    "no domains is a no-op",
+			field:   "email",
+			domains: nil,
+			want:    "",
+		},
+		{
+			name:    "blank domains are skipped",
+			field:   "email",
+			domains: []string{"", "   "},
+			want:    "",
+		},
+		{
+			name:    "domains are trimmed and lowercased",
+			field:   "email",
+			domains: []string{" DraftKings.com "},
+			want:    "emailENDSWITH@draftkings.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildDomainQuery(tc.field, tc.domains)
+			if got != tc.want {
+				t.Errorf("buildDomainQuery(%q, %v) = %q, want %q", tc.field, tc.domains, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPrepareUserFilters_Regression pins the pre-refactor byte-for-byte
+// output of prepareUserFilters now that it's built on top of buildDomainQuery.
+func TestPrepareUserFilters_Regression(t *testing.T) {
+	got := prepareUserFilters([]string{"a.com"}, nil)
+	want := "emailENDSWITH@a.com"
+	if got.Query != want {
+		t.Errorf("prepareUserFilters(...).Query = %q, want %q", got.Query, want)
+	}
+}
+
+func TestPrepareUserToRoleFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		userId  string
+		roleId  string
+		domains []string
+		want    string
+	}{
+		{
+			name:    "enumeration (Grants) with allowed domains filters by domain",
+			userId:  "",
+			roleId:  "ROLE1",
+			domains: []string{"draftkings.com"},
+			want:    "role=ROLE1^user.emailENDSWITH@draftkings.com",
+		},
+		{
+			name:    "enumeration with multiple allowed domains ORs the domain conditions, ANDed with role=",
+			userId:  "",
+			roleId:  "ROLE1",
+			domains: []string{"draftkings.com", "dk.com"},
+			want:    "role=ROLE1^user.emailENDSWITH@draftkings.com^ORuser.emailENDSWITH@dk.com",
+		},
+		{
+			name:    "provisioning check for a specific user does not filter by domain",
+			userId:  "USER1",
+			roleId:  "ROLE1",
+			domains: []string{"draftkings.com"},
+			want:    "user=USER1^role=ROLE1",
+		},
+		{
+			name:    "no allowed domains is a no-op",
+			userId:  "",
+			roleId:  "ROLE1",
+			domains: nil,
+			want:    "role=ROLE1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := prepareUserToRoleFilter(tc.userId, tc.roleId, tc.domains)
+			if got.Query != tc.want {
+				t.Errorf("prepareUserToRoleFilter(%q, %q, %v).Query = %q, want %q", tc.userId, tc.roleId, tc.domains, got.Query, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrepareUserToGroupFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		userId  string
+		groupId string
+		domains []string
+		want    string
+	}{
+		{
+			name:    "enumeration (Grants) with allowed domains filters by domain",
+			userId:  "",
+			groupId: "GROUP1",
+			domains: []string{"draftkings.com"},
+			want:    "group=GROUP1^user.emailENDSWITH@draftkings.com",
+		},
+		{
+			name:    "enumeration with multiple allowed domains ORs the domain conditions, ANDed with group=",
+			userId:  "",
+			groupId: "GROUP1",
+			domains: []string{"draftkings.com", "dk.com"},
+			want:    "group=GROUP1^user.emailENDSWITH@draftkings.com^ORuser.emailENDSWITH@dk.com",
+		},
+		{
+			name:    "provisioning check for a specific user does not filter by domain",
+			userId:  "USER1",
+			groupId: "GROUP1",
+			domains: []string{"draftkings.com"},
+			want:    "user=USER1^group=GROUP1",
+		},
+		{
+			name:    "no allowed domains is a no-op",
+			userId:  "",
+			groupId: "GROUP1",
+			domains: nil,
+			want:    "group=GROUP1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := prepareUserToGroupFilter(tc.userId, tc.groupId, tc.domains)
+			if got.Query != tc.want {
+				t.Errorf("prepareUserToGroupFilter(%q, %q, %v).Query = %q, want %q", tc.userId, tc.groupId, tc.domains, got.Query, tc.want)
+			}
+		})
+	}
+}
+
+func TestKeysetCursorFragment(t *testing.T) {
+	tests := []struct {
+		name   string
+		lastID string
+		want   string
+	}{
+		{
+			name:   "first page orders by sys_id without seeking",
+			lastID: "",
+			want:   "ORDERBYsys_id",
+		},
+		{
+			name:   "subsequent page seeks past lastID with the literal > operator",
+			lastID: "abc123",
+			want:   "sys_id>abc123^ORDERBYsys_id",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := keysetCursorFragment(tc.lastID)
+			if got != tc.want {
+				t.Errorf("keysetCursorFragment(%q) = %q, want %q", tc.lastID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestKeysetPaginationVarsToReqOptions_ComposesWithFilterQuery mirrors how
+// client.go builds requests: filter options first, then keyset pagination
+// options appended after in the same ReqOpt slice. The seek condition must
+// AND onto the existing filter query rather than clobbering it.
+func TestKeysetPaginationVarsToReqOptions_ComposesWithFilterQuery(t *testing.T) {
+	filterOpts := filterToReqOptions(prepareUserToRoleFilter("", "ROLE1", []string{"draftkings.com"}))
+	paginationOpts := keysetPaginationVarsToReqOptions(&KeysetPaginationVars{Limit: 50, LastID: "abc123"})
+
+	req := newTestRequest(t)
+	applyReqOpts(req, filterOpts...)
+	applyReqOpts(req, paginationOpts...)
+
+	wantQuery := "role=ROLE1^user.emailENDSWITH@draftkings.com^sys_id>abc123^ORDERBYsys_id"
+	if got := req.URL.Query().Get("sysparm_query"); got != wantQuery {
+		t.Errorf("sysparm_query = %q, want %q", got, wantQuery)
+	}
+	if got := req.URL.Query().Get("sysparm_limit"); got != "50" {
+		t.Errorf("sysparm_limit = %q, want %q", got, "50")
+	}
+	// ServiceNow computes X-Total-Count (a COUNT(*) over the whole filtered
+	// set) unless told not to, which is expensive on every page. Termination
+	// keys off an empty page only (see nextKeysetToken), so the count is
+	// suppressed because it's never read.
+	if got := req.URL.Query().Get("sysparm_no_count"); got != "true" {
+		t.Errorf("sysparm_no_count = %q, want %q", got, "true")
+	}
+}
+
+func TestWithNoCount(t *testing.T) {
+	req := newTestRequest(t)
+	applyReqOpts(req, WithNoCount())
+
+	if got := req.URL.Query().Get("sysparm_no_count"); got != "true" {
+		t.Errorf("sysparm_no_count = %q, want %q", got, "true")
+	}
+}
+
+func TestNextKeysetToken(t *testing.T) {
+	type item struct{ id string }
+	idFn := func(i item) string { return i.id }
+
+	// ServiceNow doesn't reliably honor sysparm_limit's exact row count, so
+	// termination must key off an empty page only -- a short-but-nonempty
+	// page must still continue, or the listing silently truncates.
+	t.Run("short but nonempty page continues pagination", func(t *testing.T) {
+		items := []item{{"a"}, {"b"}}
+		got := nextKeysetToken(items, idFn)
+		if got != "b" {
+			t.Errorf("nextKeysetToken(...) = %q, want %q (must not treat a short page as the last one)", got, "b")
+		}
+	})
+
+	t.Run("full page continues from the last row's sys_id", func(t *testing.T) {
+		items := []item{{"a"}, {"b"}, {"c"}}
+		got := nextKeysetToken(items, idFn)
+		if got != "c" {
+			t.Errorf("nextKeysetToken(...) = %q, want %q", got, "c")
+		}
+	})
+
+	t.Run("empty page terminates pagination", func(t *testing.T) {
+		got := nextKeysetToken([]item{}, idFn)
+		if got != "" {
+			t.Errorf("nextKeysetToken(...) = %q, want empty token", got)
+		}
+	})
+}
+
+// TestCappedForDomainFilter covers the page-size cap for the
+// allowed-domains dot-walk filter (user.emailENDSWITH). The cap must apply
+// only when the domain filter itself would apply (enumeration, userId=="",
+// with allowed-domains configured) -- never to provisioning checks or when
+// no domains are set.
+func TestCappedForDomainFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		userId  string
+		domains []string
+		limit   int
+		want    int
+	}{
+		{
+			name:    "enumeration with allowed domains caps a larger limit",
+			userId:  "",
+			domains: []string{"draftkings.com"},
+			limit:   200,
+			want:    domainFilteredPageSize,
+		},
+		{
+			name:    "enumeration with allowed domains leaves an already-small limit alone",
+			userId:  "",
+			domains: []string{"draftkings.com"},
+			limit:   10,
+			want:    10,
+		},
+		{
+			name:    "provisioning check (specific userId) is never capped",
+			userId:  "USER1",
+			domains: []string{"draftkings.com"},
+			limit:   200,
+			want:    200,
+		},
+		{
+			name:    "no allowed domains is never capped",
+			userId:  "",
+			domains: nil,
+			limit:   200,
+			want:    200,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cappedForDomainFilter(tc.userId, tc.domains, KeysetPaginationVars{Limit: tc.limit})
+			if got.Limit != tc.want {
+				t.Errorf("cappedForDomainFilter(%q, %v, Limit:%d).Limit = %d, want %d", tc.userId, tc.domains, tc.limit, got.Limit, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/servicenow/request_test.go
+++ b/pkg/servicenow/request_test.go
@@ -232,6 +232,27 @@ func TestKeysetPaginationVarsToReqOptions_ComposesWithFilterQuery(t *testing.T) 
 	}
 }
 
+// TestKeysetPaginationVarsToReqOptions_ComposesWithMultiDomainFilterQuery is
+// the 2+ allowed-domains variant of the test above: the seek condition must
+// AND onto the *entire* filter query, including every OR'd domain branch,
+// not just the last one. Confirmed against a real ServiceNow instance: a
+// role/group scope combined with a 2-domain filter and an unsatisfiable seek
+// (sys_id greater than the max possible value) returned zero rows, proving
+// the seek constrains every branch rather than only the trailing one.
+func TestKeysetPaginationVarsToReqOptions_ComposesWithMultiDomainFilterQuery(t *testing.T) {
+	filterOpts := filterToReqOptions(prepareUserToRoleFilter("", "ROLE1", []string{"draftkings.com", "dk.com"}))
+	paginationOpts := keysetPaginationVarsToReqOptions(&KeysetPaginationVars{Limit: 50, LastID: "abc123"})
+
+	req := newTestRequest(t)
+	applyReqOpts(req, filterOpts...)
+	applyReqOpts(req, paginationOpts...)
+
+	wantQuery := "role=ROLE1^user.emailENDSWITH@draftkings.com^ORuser.emailENDSWITH@dk.com^sys_id>abc123^ORDERBYsys_id"
+	if got := req.URL.Query().Get("sysparm_query"); got != wantQuery {
+		t.Errorf("sysparm_query = %q, want %q", got, wantQuery)
+	}
+}
+
 func TestWithNoCount(t *testing.T) {
 	req := newTestRequest(t)
 	applyReqOpts(req, WithNoCount())


### PR DESCRIPTION
Grant sync could get stuck indefinitely on large ServiceNow instances. Role and group membership listings paginated using an offset parameter, and ServiceNow gets progressively slower the deeper you page through that way, since it has to re-scan and discard every row before the one you're asking for. Eventually a single page took longer than the configured timeout, the sync failed, and the whole thing restarted and hit the same wall again, forever.

This change switches those listings to keyset pagination instead: rather than saying "skip N rows," each page asks for "rows after the last one I saw," using the row's own ID as the marker. That keeps the cost of a single page roughly constant no matter how deep you go, since it's an indexed lookup rather than a scan-and-discard. A page only counts as the last one when it comes back completely empty, since ServiceNow doesn't always return the exact number of rows you asked for, so a short page isn't a safe signal to stop.

Role and group membership listings also now apply the same allowed-domains filter that user listing already used, but only when listing everything, not when checking one specific user for provisioning. Before this, membership listings ignored that filter, so on instances with a lot of out-of-domain accounts they were slower than they needed to be and could produce grants for users who never actually got synced as a resource. Page size for these listings went from 50 to 200 rows per request, except when the domain filter is active, where it's capped back down to 50, since that filter can't use an index and a bigger page means more scanning per request.

A few unrelated deprecation warnings also got fixed, surfaced by bumping the SDK dependency, in resource-building code this change doesn't otherwise touch.