### PR TITLE
Fix ServiceNow action argument names and document allowed-domains scope

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -26,8 +26,8 @@ Connector actions are custom capabilities that extend C1 automations with app-sp
 
 | Action name | Additional fields | Description |
 |-------------|-------------------|-------------|
-| enable_user | `user_id` (string, required) | Enables a disabled ServiceNow user account |
-| disable_user     | `user_id` (string, required) | Disables an active ServiceNow user account |
+| enable_user | `userId` (string, required) | Enables a disabled ServiceNow user account |
+| disable_user     | `userId` (string, required) | Disables an active ServiceNow user account |
 
 ## Gather ServiceNow credentials 
 
@@ -247,11 +247,11 @@ Click **Next**.
 Find the **Settings** area of the page and click **Edit**.
 </Step>
 <Step>
-**Optional.** In the **Allowed emails domains** field, enter the email domain or domains (such as `acme.com` and `contractors.acme.com`) associated with the accounts that you want C1 to sync.
+**Optional.** In the **Allowed emails domains** field, enter the email domain or domains (such as `acme.com` and `contractors.acme.com`) associated with the accounts that you want C1 to sync. When set, C1 also filters group and role membership grants to only include users whose email matches an allowed domain.
 
    To add multiple allowed domains, press **Enter** between each domain.
 
-   If you leave this field blank, C1 will sync all accounts in your ServiceNow instance, regardless of the email domain associated with the account.
+   If you leave this field blank, C1 will sync all accounts and membership grants in your ServiceNow instance, regardless of the email domain associated with the account.
 </Step>
 <Step>
 **Optional.** In the **Custom user attributes** field, enter the names of any custom user attribute fields you want C1 to sync from ServiceNow. These are fields that start with `u_` in ServiceNow, such as `u_type`.
@@ -366,7 +366,7 @@ stringData:
   # Optional: include if you want C1 to provision access using this connector
   BATON_PROVISIONING: true
 
-  # Optional: include if you want to limit account syncing to only accounts associated with an email domain listed here
+  # Optional: include if you want to limit syncing to accounts and membership grants associated with an email domain listed here
   # Note: include each allowed domain as a separate entry
   BATON_ALLOWED_DOMAINS: <Email domain, such as "acme.com">
   BATON_ALLOWED_DOMAINS: <Email domain, such as "contractors.acme.com">


### PR DESCRIPTION
## Summary

- Fix action argument names: the `enable_user` and `disable_user` connector actions documented the argument as `user_id`, but the connector expects `userId` (confirmed in `pkg/connector/actions.go`). Using the documented name always fails with `missing required argument userId`.
- Document allowed-domains scope: `allowed-domains` filters group and role membership grants in addition to account syncing (confirmed via `GetUserToGroup`/`GetUserToRole` in `pkg/servicenow/client.go`). Updated the cloud-hosted setup description and the self-hosted YAML comment to reflect the broader scope.

This mirrors a fix already applied to the rendered docs at ConductorOne/docs#428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)