### PR TITLE
cxp-830 fix: report ServiceNow rate limit data to the SDK

### DIFF
--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -104,10 +104,10 @@ func (s *ServiceNow) enableUser(ctx context.Context, args *structpb.Struct) (*st
 
 	l.Info("enabling user", zap.String("userId", userIdStr))
 
-	updatedUser, err := s.client.UpdateUserActiveStatus(ctx, userIdStr, true)
+	updatedUser, annos, err := s.client.UpdateUserActiveStatus(ctx, userIdStr, true)
 	if err != nil {
 		l.Error("failed to enable user", zap.String("userId", userIdStr), zap.Error(err))
-		return nil, nil, fmt.Errorf("baton-servicenow: failed to enable user %s: %w", userIdStr, err)
+		return nil, annos, fmt.Errorf("baton-servicenow: failed to enable user %s: %w", userIdStr, err)
 	}
 
 	success := updatedUser.Active == "true"
@@ -120,7 +120,7 @@ func (s *ServiceNow) enableUser(ctx context.Context, args *structpb.Struct) (*st
 			"success": structpb.NewBoolValue(success),
 		},
 	}
-	return response, nil, nil
+	return response, annos, nil
 }
 
 func (s *ServiceNow) disableUser(ctx context.Context, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
@@ -150,10 +150,10 @@ func (s *ServiceNow) disableUser(ctx context.Context, args *structpb.Struct) (*s
 
 	l.Info("disabling user", zap.String("userId", userIdStr))
 
-	updatedUser, err := s.client.UpdateUserActiveStatus(ctx, userIdStr, false)
+	updatedUser, annos, err := s.client.UpdateUserActiveStatus(ctx, userIdStr, false)
 	if err != nil {
 		l.Error("failed to disable user", zap.String("userId", userIdStr), zap.Error(err))
-		return nil, nil, fmt.Errorf("baton-servicenow: failed to disable user %s: %w", userIdStr, err)
+		return nil, annos, fmt.Errorf("baton-servicenow: failed to disable user %s: %w", userIdStr, err)
 	}
 
 	success := updatedUser.Active == "false"
@@ -166,5 +166,5 @@ func (s *ServiceNow) disableUser(ctx context.Context, args *structpb.Struct) (*s
 			"success": structpb.NewBoolValue(success),
 		},
 	}
-	return response, nil, nil
+	return response, annos, nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -107,12 +107,12 @@ func (s *ServiceNow) Validate(ctx context.Context) (annotations.Annotations, err
 		Limit: 1,
 	}
 
-	_, _, err := s.client.GetUsers(ctx, pagination)
+	_, _, annos, err := s.client.GetUsers(ctx, pagination)
 	if err != nil {
-		return nil, fmt.Errorf("baton-servicenow: current user is not able to list users: %w", err)
+		return annos, fmt.Errorf("baton-servicenow: current user is not able to list users: %w", err)
 	}
 
-	return nil, nil
+	return annos, nil
 }
 
 // New returns the ServiceNow connector.
@@ -129,7 +129,14 @@ func New(
 		return nil, err
 	}
 
-	servicenowClient, err := servicenow.NewClient(httpClient, auth, deployment, ticketSchemaFilters, allowedDomains, customUserFields, baseURL)
+	// BaseHttpClient is what makes uhttp's DoOptions (notably
+	// WithRatelimitData) available to the client layer.
+	baseHttpClient, err := uhttp.NewBaseHttpClientWithContext(ctx, httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	servicenowClient, err := servicenow.NewClient(baseHttpClient, auth, deployment, ticketSchemaFilters, allowedDomains, customUserFields, baseURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -169,14 +169,14 @@ func (r *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 	}
 
 	groupId := entitlement.Resource.Id.Resource
-	groupMembers, _, _, err := r.client.GetUserToGroup(
+	groupMembers, _, annos, err := r.client.GetUserToGroup(
 		ctx,
 		principal.Id.Resource,
 		groupId,
 		servicenow.KeysetPaginationVars{Limit: 1},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("baton-servicenow: failed to get group members for %s: %w", entitlement.Id, err)
+		return annos, fmt.Errorf("baton-servicenow: failed to get group members for %s: %w", entitlement.Id, err)
 	}
 
 	// check if user is already a member of the group
@@ -187,11 +187,14 @@ func (r *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 			zap.String("user", principal.Id.Resource),
 		)
 
-		return annotations.New(&v2.GrantAlreadyExists{}), nil
+		// Update, not annotations.New: the latter would discard the
+		// rate-limit annotation already in the bag.
+		annos.Update(&v2.GrantAlreadyExists{})
+		return annos, nil
 	}
 
 	// grant group membership to the user
-	err = r.client.AddUserToGroup(
+	annos, err = r.client.AddUserToGroup(
 		ctx,
 		servicenow.GroupMemberPayload{
 			User:  principal.Id.Resource,
@@ -199,10 +202,10 @@ func (r *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("baton-servicenow: failed to add user %s to group %s: %w", principal.Id.Resource, groupId, err)
+		return annos, fmt.Errorf("baton-servicenow: failed to add user %s to group %s: %w", principal.Id.Resource, groupId, err)
 	}
 
-	return nil, nil
+	return annos, nil
 }
 
 func (r *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {
@@ -220,14 +223,14 @@ func (r *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annota
 	}
 
 	groupId := entitlement.Resource.Id.Resource
-	groupMembers, _, _, err := r.client.GetUserToGroup(
+	groupMembers, _, annos, err := r.client.GetUserToGroup(
 		ctx,
 		principal.Id.Resource,
 		groupId,
 		servicenow.KeysetPaginationVars{Limit: 1},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("baton-servicenow: failed to get user roles for %s: %w", grant.Principal.Id.Resource, err)
+		return annos, fmt.Errorf("baton-servicenow: failed to get user roles for %s: %w", grant.Principal.Id.Resource, err)
 	}
 
 	// check if group is empty
@@ -238,23 +241,26 @@ func (r *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annota
 			zap.String("user", principal.Id.Resource),
 		)
 
-		return annotations.New(&v2.GrantAlreadyRevoked{}), nil
+		// Update, not annotations.New: the latter would discard the
+		// rate-limit annotation already in the bag.
+		annos.Update(&v2.GrantAlreadyRevoked{})
+		return annos, nil
 	}
 
 	// revoke all group memberships from the user
 	for _, grpMember := range groupMembers {
-		err = r.client.RemoveUserFromGroup(
+		annos, err = r.client.RemoveUserFromGroup(
 			ctx,
 			grpMember.Id,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("baton-servicenow: failed to remove user %s from group: %w", grant.Principal.Id.Resource, err)
+			return annos, fmt.Errorf("baton-servicenow: failed to remove user %s from group: %w", grant.Principal.Id.Resource, err)
 		}
 
 		l.Debug("revoked role from user", zap.String("role", grant.Entitlement.Id))
 	}
 
-	return nil, nil
+	return annos, nil
 }
 
 func groupBuilder(client *servicenow.Client) *groupResourceType {

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -55,7 +55,7 @@ func (g *groupResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagi
 		return nil, "", nil, err
 	}
 
-	groups, nextPageToken, err := g.client.GetGroups(
+	groups, nextPageToken, annos, err := g.client.GetGroups(
 		ctx,
 		servicenow.KeysetPaginationVars{
 			Limit:  ResourcesPageSize,
@@ -64,12 +64,12 @@ func (g *groupResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagi
 		nil,
 	)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("baton-servicenow: failed to list groups: %w", err)
+		return nil, "", annos, fmt.Errorf("baton-servicenow: failed to list groups: %w", err)
 	}
 
 	nextPage, err := bag.NextToken(nextPageToken)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", annos, err
 	}
 
 	var rv []*v2.Resource
@@ -78,13 +78,13 @@ func (g *groupResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagi
 		rr, err := groupResource(&groupCopy)
 
 		if err != nil {
-			return nil, "", nil, err
+			return nil, "", annos, err
 		}
 
 		rv = append(rv, rr)
 	}
 
-	return rv, nextPage, nil, nil
+	return rv, nextPage, annos, nil
 }
 
 func (g *groupResourceType) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
@@ -111,7 +111,7 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, p
 		return nil, "", nil, err
 	}
 
-	groupMembers, nextPageToken, err := g.client.GetUserToGroup(
+	groupMembers, nextPageToken, annos, err := g.client.GetUserToGroup(
 		ctx,
 		"", // all users, domain-filtered when allowed-domains is set
 		resource.Id.Resource,
@@ -121,24 +121,24 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, p
 		},
 	)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("baton-servicenow: failed to list groupMembers: %w", err)
+		return nil, "", annos, fmt.Errorf("baton-servicenow: failed to list groupMembers: %w", err)
 	}
 
 	nextPage, err := bag.NextToken(nextPageToken)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", annos, err
 	}
 
 	memberIDs := mapGroupMembers(groupMembers)
 	if len(memberIDs) == 0 {
-		return []*v2.Grant{}, nextPage, nil, nil
+		return []*v2.Grant{}, nextPage, annos, nil
 	}
 
 	var rv []*v2.Grant
 	for _, member := range memberIDs {
 		rID, err := rs.NewResourceID(resourceTypeUser, member)
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("baton-servicenow: error creating principal id for member %s: %w", member, err)
+			return nil, "", annos, fmt.Errorf("baton-servicenow: error creating principal id for member %s: %w", member, err)
 		}
 
 		// grant group membership
@@ -152,7 +152,7 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, p
 		)
 	}
 
-	return rv, nextPage, nil, nil
+	return rv, nextPage, annos, nil
 }
 
 func (r *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) (annotations.Annotations, error) {
@@ -169,7 +169,7 @@ func (r *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 	}
 
 	groupId := entitlement.Resource.Id.Resource
-	groupMembers, _, err := r.client.GetUserToGroup(
+	groupMembers, _, _, err := r.client.GetUserToGroup(
 		ctx,
 		principal.Id.Resource,
 		groupId,
@@ -220,7 +220,7 @@ func (r *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annota
 	}
 
 	groupId := entitlement.Resource.Id.Resource
-	groupMembers, _, err := r.client.GetUserToGroup(
+	groupMembers, _, _, err := r.client.GetUserToGroup(
 		ctx,
 		principal.Id.Resource,
 		groupId,

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -220,14 +220,14 @@ func (r *roleResourceType) helperGrantForGroup(role servicenow.GroupToRole) []gr
 }
 
 func (r *roleResourceType) GrantToUser(ctx context.Context, l *zap.Logger, principal string, roleId string) (annotations.Annotations, error) {
-	userRoles, _, _, err := r.client.GetUserToRole(
+	userRoles, _, annos, err := r.client.GetUserToRole(
 		ctx,
 		principal,
 		roleId,
 		servicenow.KeysetPaginationVars{Limit: 1},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("baton-servicenow: failed to get user roles for %s: %w", principal, err)
+		return annos, fmt.Errorf("baton-servicenow: failed to get user roles for %s: %w", principal, err)
 	}
 
 	// check if the user already has the role
@@ -238,11 +238,14 @@ func (r *roleResourceType) GrantToUser(ctx context.Context, l *zap.Logger, princ
 			zap.String("role", roleId),
 		)
 
-		return annotations.New(&v2.GrantAlreadyExists{}), nil
+		// Update, not annotations.New: the latter would discard the
+		// rate-limit annotation already in the bag.
+		annos.Update(&v2.GrantAlreadyExists{})
+		return annos, nil
 	}
 
 	// grant the role to the user
-	err = r.client.GrantRoleToUser(
+	annos, err = r.client.GrantRoleToUser(
 		ctx,
 		servicenow.UserToRolePayload{
 			User: principal,
@@ -250,22 +253,22 @@ func (r *roleResourceType) GrantToUser(ctx context.Context, l *zap.Logger, princ
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("baton-servicenow: failed to grant role %s to user %s: %w", roleId, principal, err)
+		return annos, fmt.Errorf("baton-servicenow: failed to grant role %s to user %s: %w", roleId, principal, err)
 	}
 
 	l.Debug("granted role to user", zap.String("role", roleId))
-	return nil, nil
+	return annos, nil
 }
 
 func (r *roleResourceType) GrantToGroup(ctx context.Context, l *zap.Logger, principal string, roleId string) (annotations.Annotations, error) {
-	groupRoles, _, _, err := r.client.GetGroupToRole(
+	groupRoles, _, annos, err := r.client.GetGroupToRole(
 		ctx,
 		principal,
 		roleId,
 		servicenow.KeysetPaginationVars{Limit: 1},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("baton-servicenow: failed to get group roles for %s: %w", principal, err)
+		return annos, fmt.Errorf("baton-servicenow: failed to get group roles for %s: %w", principal, err)
 	}
 
 	// check if the group already has the role
@@ -276,11 +279,11 @@ func (r *roleResourceType) GrantToGroup(ctx context.Context, l *zap.Logger, prin
 			zap.String("role", roleId),
 		)
 
-		return nil, fmt.Errorf("baton-servicenow: group already has specified role")
+		return annos, fmt.Errorf("baton-servicenow: group already has specified role")
 	}
 
 	// grant the role to the group
-	err = r.client.GrantRoleToGroup(
+	annos, err = r.client.GrantRoleToGroup(
 		ctx,
 		servicenow.GroupToRolePayload{
 			Group: principal,
@@ -288,11 +291,11 @@ func (r *roleResourceType) GrantToGroup(ctx context.Context, l *zap.Logger, prin
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("baton-servicenow: failed to grant role %s to group %s: %w", roleId, principal, err)
+		return annos, fmt.Errorf("baton-servicenow: failed to grant role %s to group %s: %w", roleId, principal, err)
 	}
 
 	l.Debug("granted role to group", zap.String("role", roleId))
-	return nil, nil
+	return annos, nil
 }
 
 func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) (annotations.Annotations, error) {
@@ -326,14 +329,14 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 
 func (r *roleResourceType) RevokeFromUser(ctx context.Context, l *zap.Logger, principal *v2.Resource, roleId string) (annotations.Annotations, error) {
 	// check if role is present
-	userRoles, _, _, err := r.client.GetUserToRole(
+	userRoles, _, annos, err := r.client.GetUserToRole(
 		ctx,
 		principal.Id.Resource,
 		roleId,
 		servicenow.KeysetPaginationVars{Limit: 1},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("baton-servicenow: failed to get user roles for %s: %w", principal.Id.Resource, err)
+		return annos, fmt.Errorf("baton-servicenow: failed to get user roles for %s: %w", principal.Id.Resource, err)
 	}
 
 	if len(userRoles) == 0 {
@@ -343,35 +346,38 @@ func (r *roleResourceType) RevokeFromUser(ctx context.Context, l *zap.Logger, pr
 			zap.String("role", roleId),
 		)
 
-		return annotations.New(&v2.GrantAlreadyRevoked{}), nil
+		// Update, not annotations.New: the latter would discard the
+		// rate-limit annotation already in the bag.
+		annos.Update(&v2.GrantAlreadyRevoked{})
+		return annos, nil
 	}
 
 	// revoke all roles (inherited or not) from the user
 	for _, userRole := range userRoles {
-		err = r.client.RevokeRoleFromUser(
+		annos, err = r.client.RevokeRoleFromUser(
 			ctx,
 			userRole.Id,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("baton-servicenow: failed to revoke role %s from user %s: %w", roleId, principal.Id.Resource, err)
+			return annos, fmt.Errorf("baton-servicenow: failed to revoke role %s from user %s: %w", roleId, principal.Id.Resource, err)
 		}
 
 		l.Debug("revoked role from user", zap.String("role", roleId))
 	}
 
-	return nil, nil
+	return annos, nil
 }
 
 func (r *roleResourceType) RevokeFromGroup(ctx context.Context, l *zap.Logger, principal *v2.Resource, roleId string) (annotations.Annotations, error) {
 	// check if role is present
-	groupRoles, _, _, err := r.client.GetGroupToRole(
+	groupRoles, _, annos, err := r.client.GetGroupToRole(
 		ctx,
 		principal.Id.Resource,
 		roleId,
 		servicenow.KeysetPaginationVars{Limit: 1},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("baton-servicenow: failed to get group roles for %s: %w", principal.Id.Resource, err)
+		return annos, fmt.Errorf("baton-servicenow: failed to get group roles for %s: %w", principal.Id.Resource, err)
 	}
 
 	if len(groupRoles) == 0 {
@@ -381,23 +387,23 @@ func (r *roleResourceType) RevokeFromGroup(ctx context.Context, l *zap.Logger, p
 			zap.String("role", roleId),
 		)
 
-		return nil, fmt.Errorf("baton-servicenow: cannot revoke not existing role from group")
+		return annos, fmt.Errorf("baton-servicenow: cannot revoke not existing role from group")
 	}
 
 	// revoke all roles (inherited or not) from the group
 	for _, groupRole := range groupRoles {
-		err = r.client.RevokeRoleFromGroup(
+		annos, err = r.client.RevokeRoleFromGroup(
 			ctx,
 			groupRole.Id,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("baton-servicenow: failed to revoke role %s from group %s: %w", roleId, principal.Id.Resource, err)
+			return annos, fmt.Errorf("baton-servicenow: failed to revoke role %s from group %s: %w", roleId, principal.Id.Resource, err)
 		}
 
 		l.Debug("revoked role from group", zap.String("role", roleId))
 	}
 
-	return nil, nil
+	return annos, nil
 }
 
 func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -54,7 +54,7 @@ func (r *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagin
 		return nil, "", nil, err
 	}
 
-	roles, nextPageToken, err := r.client.GetRoles(
+	roles, nextPageToken, annos, err := r.client.GetRoles(
 		ctx,
 		servicenow.KeysetPaginationVars{
 			Limit:  ResourcesPageSize,
@@ -62,12 +62,12 @@ func (r *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagin
 		},
 	)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("baton-servicenow: failed to list roles: %w", err)
+		return nil, "", annos, fmt.Errorf("baton-servicenow: failed to list roles: %w", err)
 	}
 
 	nextPage, err := bag.NextToken(nextPageToken)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", annos, err
 	}
 
 	var rv []*v2.Resource
@@ -76,13 +76,13 @@ func (r *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagin
 		rr, err := roleResource(&roleCopy)
 
 		if err != nil {
-			return nil, "", nil, err
+			return nil, "", annos, err
 		}
 
 		rv = append(rv, rr)
 	}
 
-	return rv, nextPage, nil, nil
+	return rv, nextPage, annos, nil
 }
 
 func (r *roleResourceType) Entitlements(ctx context.Context, resource *v2.Resource, token *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
@@ -110,6 +110,10 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 	}
 
 	var rv []*v2.Grant
+	// Carries the rate-limit annotations from whichever branch issued a
+	// request, so they reach the SDK limiter regardless of which membership
+	// table this page came from.
+	var annos annotations.Annotations
 	switch bag.ResourceTypeID() {
 	case resourceTypeRole.Id:
 		bag.Pop()
@@ -121,7 +125,7 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 		})
 
 	case resourceTypeUser.Id:
-		usersToRoles, nextPageToken, err := r.client.GetUserToRole(
+		usersToRoles, nextPageToken, userAnnos, err := r.client.GetUserToRole(
 			ctx,
 			"", // all users, domain-filtered when allowed-domains is set
 			resource.Id.Resource,
@@ -130,13 +134,14 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 				LastID: lastID,
 			},
 		)
+		annos = userAnnos
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("baton-servicenow: failed to list users under role %s: %w", resource.Id.Resource, err)
+			return nil, "", annos, fmt.Errorf("baton-servicenow: failed to list users under role %s: %w", resource.Id.Resource, err)
 		}
 
 		err = bag.Next(nextPageToken)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, "", annos, err
 		}
 
 		// for each roleBinding, create a grant
@@ -155,7 +160,7 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 		}
 
 	case resourceTypeGroup.Id:
-		groupsToRoles, nextPageToken, err := r.client.GetGroupToRole(
+		groupsToRoles, nextPageToken, groupAnnos, err := r.client.GetGroupToRole(
 			ctx,
 			"", // all groups
 			resource.Id.Resource,
@@ -164,13 +169,14 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 				LastID: lastID,
 			},
 		)
+		annos = groupAnnos
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("baton-servicenow: failed to list groups under role %s: %w", resource.Id.Resource, err)
+			return nil, "", annos, fmt.Errorf("baton-servicenow: failed to list groups under role %s: %w", resource.Id.Resource, err)
 		}
 
 		err = bag.Next(nextPageToken)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, "", annos, err
 		}
 
 		// for each roleBinding, create a grant
@@ -195,10 +201,10 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 
 	nextPage, err := bag.Marshal()
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", annos, err
 	}
 
-	return rv, nextPage, nil, nil
+	return rv, nextPage, annos, nil
 }
 
 // This is a helper function to add heritance.
@@ -214,7 +220,7 @@ func (r *roleResourceType) helperGrantForGroup(role servicenow.GroupToRole) []gr
 }
 
 func (r *roleResourceType) GrantToUser(ctx context.Context, l *zap.Logger, principal string, roleId string) (annotations.Annotations, error) {
-	userRoles, _, err := r.client.GetUserToRole(
+	userRoles, _, _, err := r.client.GetUserToRole(
 		ctx,
 		principal,
 		roleId,
@@ -252,7 +258,7 @@ func (r *roleResourceType) GrantToUser(ctx context.Context, l *zap.Logger, princ
 }
 
 func (r *roleResourceType) GrantToGroup(ctx context.Context, l *zap.Logger, principal string, roleId string) (annotations.Annotations, error) {
-	groupRoles, _, err := r.client.GetGroupToRole(
+	groupRoles, _, _, err := r.client.GetGroupToRole(
 		ctx,
 		principal,
 		roleId,
@@ -320,7 +326,7 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 
 func (r *roleResourceType) RevokeFromUser(ctx context.Context, l *zap.Logger, principal *v2.Resource, roleId string) (annotations.Annotations, error) {
 	// check if role is present
-	userRoles, _, err := r.client.GetUserToRole(
+	userRoles, _, _, err := r.client.GetUserToRole(
 		ctx,
 		principal.Id.Resource,
 		roleId,
@@ -358,7 +364,7 @@ func (r *roleResourceType) RevokeFromUser(ctx context.Context, l *zap.Logger, pr
 
 func (r *roleResourceType) RevokeFromGroup(ctx context.Context, l *zap.Logger, principal *v2.Resource, roleId string) (annotations.Annotations, error) {
 	// check if role is present
-	groupRoles, _, err := r.client.GetGroupToRole(
+	groupRoles, _, _, err := r.client.GetGroupToRole(
 		ctx,
 		principal.Id.Resource,
 		roleId,

--- a/pkg/connector/ticket.go
+++ b/pkg/connector/ticket.go
@@ -34,14 +34,14 @@ func (s *ServiceNow) ListTicketSchemas(ctx context.Context, pt *pagination.Token
 	if pageSize > TicketSchemasPageSize {
 		pageSize = TicketSchemasPageSize
 	}
-	catalogItems, nextPageToken, err := s.client.GetCatalogItems(ctx,
+	catalogItems, nextPageToken, annos, err := s.client.GetCatalogItems(ctx,
 		&servicenow.PaginationVars{
 			Limit:  pageSize,
 			Offset: offset,
 		},
 	)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("baton-servicenow: failed to get catalog items: %w", err)
+		return nil, "", annos, fmt.Errorf("baton-servicenow: failed to get catalog items: %w", err)
 	}
 
 	l.Debug("listing ticket schemas",
@@ -51,9 +51,9 @@ func (s *ServiceNow) ListTicketSchemas(ctx context.Context, pt *pagination.Token
 		zap.String("next_page_token", nextPageToken),
 	)
 
-	requestedItemStates, err := s.client.GetServiceCatalogRequestedItemStates(ctx)
+	requestedItemStates, annos, err := s.client.GetServiceCatalogRequestedItemStates(ctx)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("baton-servicenow: failed to get catalog requested item states: %w", err)
+		return nil, "", annos, fmt.Errorf("baton-servicenow: failed to get catalog requested item states: %w", err)
 	}
 
 	ticketStatuses := requestedItemStatesToTicketStatus(requestedItemStates)
@@ -61,25 +61,26 @@ func (s *ServiceNow) ListTicketSchemas(ctx context.Context, pt *pagination.Token
 	var ret []*v2.TicketSchema
 	for _, catalogItem := range catalogItems {
 		catalogItem := catalogItem
-		catalogItemSchema, err := s.schemaForCatalogItem(ctx, &catalogItem)
+		catalogItemSchema, schemaAnnos, err := s.schemaForCatalogItem(ctx, &catalogItem)
+		annos = schemaAnnos
 		if err != nil {
-			return nil, "", nil, err
+			return nil, "", annos, err
 		}
 		catalogItemSchema.Statuses = ticketStatuses
 		ret = append(ret, catalogItemSchema)
 	}
 
-	return ret, nextPageToken, nil, nil
+	return ret, nextPageToken, annos, nil
 }
 
 func (s *ServiceNow) GetTicket(ctx context.Context, ticketId string) (*v2.Ticket, annotations.Annotations, error) {
-	serviceCatalogRequestedItem, err := s.client.GetServiceCatalogRequestItem(ctx, ticketId)
+	serviceCatalogRequestedItem, annos, err := s.client.GetServiceCatalogRequestItem(ctx, ticketId)
 	if err != nil {
-		return nil, nil, fmt.Errorf("baton-servicenow: failed to get catalog requested item %s: %w", ticketId, err)
+		return nil, annos, fmt.Errorf("baton-servicenow: failed to get catalog requested item %s: %w", ticketId, err)
 	}
 	ticket, annos, err := s.serviceCatalogRequestItemToTicket(ctx, serviceCatalogRequestedItem)
 	if err != nil {
-		return ticket, nil, fmt.Errorf("baton-servicenow: %w", err)
+		return ticket, annos, fmt.Errorf("baton-servicenow: %w", err)
 	}
 
 	return ticket, annos, err
@@ -160,13 +161,13 @@ func (s *ServiceNow) CreateTicket(ctx context.Context, ticket *v2.Ticket, schema
 		opt(createServiceCatalogRequestPayload)
 	}
 
-	serviceCatalogRequestedItem, err := s.client.CreateServiceCatalogRequest(ctx, catalogItemID, createServiceCatalogRequestPayload)
+	serviceCatalogRequestedItem, createAnnos, err := s.client.CreateServiceCatalogRequest(ctx, catalogItemID, createServiceCatalogRequestPayload)
 	if err != nil {
-		return nil, nil, fmt.Errorf("baton-servicenow: failed to create service catalog request %s: %w", catalogItemID, err)
+		return nil, createAnnos, fmt.Errorf("baton-servicenow: failed to create service catalog request %s: %w", catalogItemID, err)
 	}
-	labelErr := s.client.AddLabelsToRequest(ctx, serviceCatalogRequestedItem.Id, ticket.Labels)
+	_, labelErr := s.client.AddLabelsToRequest(ctx, serviceCatalogRequestedItem.Id, ticket.Labels)
 
-	serviceCatalogRequestedItem, updateErr := s.client.UpdateServiceCatalogRequestItem(ctx,
+	serviceCatalogRequestedItem, _, updateErr := s.client.UpdateServiceCatalogRequestItem(ctx,
 		serviceCatalogRequestedItem.Id,
 		&servicenow.RequestedItemUpdatePayload{
 			Description: ticket.Description,
@@ -178,7 +179,7 @@ func (s *ServiceNow) CreateTicket(ctx context.Context, ticket *v2.Ticket, schema
 
 	ticket, annos, err := s.serviceCatalogRequestItemToTicket(ctx, serviceCatalogRequestedItem)
 	if err != nil {
-		return nil, nil, err
+		return nil, annos, err
 	}
 
 	err = multierr.Combine(labelErr, updateErr, err)
@@ -235,32 +236,32 @@ func (s *ServiceNow) BulkGetTickets(ctx context.Context, request *v2.TicketsServ
 }
 
 func (s *ServiceNow) GetTicketSchema(ctx context.Context, schemaID string) (*v2.TicketSchema, annotations.Annotations, error) {
-	catalogItem, err := s.client.GetCatalogItem(ctx, schemaID)
+	catalogItem, annos, err := s.client.GetCatalogItem(ctx, schemaID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("baton-servicenow: failed to get catalog item %s: %w", schemaID, err)
+		return nil, annos, fmt.Errorf("baton-servicenow: failed to get catalog item %s: %w", schemaID, err)
 	}
-	requestedItemStates, err := s.client.GetServiceCatalogRequestedItemStates(ctx)
+	requestedItemStates, annos, err := s.client.GetServiceCatalogRequestedItemStates(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("baton-servicenow: failed to get catalog requested item states: %w", err)
+		return nil, annos, fmt.Errorf("baton-servicenow: failed to get catalog requested item states: %w", err)
 	}
 	ticketStatuses := requestedItemStatesToTicketStatus(requestedItemStates)
-	schema, err := s.schemaForCatalogItem(ctx, catalogItem)
+	schema, annos, err := s.schemaForCatalogItem(ctx, catalogItem)
 	if err != nil {
-		return nil, nil, err
+		return nil, annos, err
 	}
 	schema.Statuses = ticketStatuses
-	return schema, nil, nil
+	return schema, annos, nil
 }
 
-func (s *ServiceNow) schemaForCatalogItem(ctx context.Context, catalogItem *servicenow.CatalogItem) (*v2.TicketSchema, error) {
+func (s *ServiceNow) schemaForCatalogItem(ctx context.Context, catalogItem *servicenow.CatalogItem) (*v2.TicketSchema, annotations.Annotations, error) {
 	// TODO(lauren) make type a custom field
 	var ticketTypes []*v2.TicketType
 
 	customFields := make(map[string]*v2.TicketCustomField)
 
-	variables, err := s.client.GetCatalogItemVariablesPlusSets(ctx, catalogItem.Id)
+	variables, annos, err := s.client.GetCatalogItemVariablesPlusSets(ctx, catalogItem.Id)
 	if err != nil {
-		return nil, fmt.Errorf("baton-servicenow: failed to get variables (item + sets) for catalog item %s: %w", catalogItem.Id, err)
+		return nil, annos, fmt.Errorf("baton-servicenow: failed to get variables (item + sets) for catalog item %s: %w", catalogItem.Id, err)
 	}
 
 	for _, v := range variables {
@@ -282,7 +283,7 @@ func (s *ServiceNow) schemaForCatalogItem(ctx context.Context, catalogItem *serv
 		CustomFields: customFields,
 	}
 
-	return ret, nil
+	return ret, annos, nil
 }
 
 func (s *ServiceNow) serviceCatalogRequestItemToTicket(ctx context.Context, requestedItem *servicenow.RequestedItem) (*v2.Ticket, annotations.Annotations, error) {
@@ -321,13 +322,13 @@ func (s *ServiceNow) serviceCatalogRequestItemToTicket(ctx context.Context, requ
 		CompletedAt:  completedAt,
 	}
 
-	labels, err := s.client.GetLabelsForRequestedItem(ctx, requestedItem.Id)
+	labels, annos, err := s.client.GetLabelsForRequestedItem(ctx, requestedItem.Id)
 	if err != nil {
-		return t, nil, fmt.Errorf("baton-servicenow: failed to get labels for requested item %s: %w", requestedItem.Id, err)
+		return t, annos, fmt.Errorf("baton-servicenow: failed to get labels for requested item %s: %w", requestedItem.Id, err)
 	}
 
 	t.Labels = labels
-	return t, nil, nil
+	return t, annos, nil
 }
 
 func (s *ServiceNow) generateRequestedItemURL(requestedItem *servicenow.RequestedItem) string {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -74,7 +74,7 @@ func (u *userResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagin
 		return nil, "", nil, err
 	}
 
-	users, nextPageToken, err := u.client.GetUsers(
+	users, nextPageToken, annos, err := u.client.GetUsers(
 		ctx,
 		servicenow.KeysetPaginationVars{
 			Limit:  ResourcesPageSize,
@@ -82,12 +82,12 @@ func (u *userResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagin
 		},
 	)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("baton-servicenow: failed to list users: %w", err)
+		return nil, "", annos, fmt.Errorf("baton-servicenow: failed to list users: %w", err)
 	}
 
 	nextPage, err := bag.NextToken(nextPageToken)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", annos, err
 	}
 
 	var rv []*v2.Resource
@@ -96,7 +96,7 @@ func (u *userResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagin
 		ur, err := userResource(&userCopy)
 
 		if err != nil {
-			return nil, "", nil, err
+			return nil, "", annos, err
 		}
 
 		rv = append(rv, ur)

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -102,7 +102,7 @@ func (u *userResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagin
 		rv = append(rv, ur)
 	}
 
-	return rv, nextPage, nil, nil
+	return rv, nextPage, annos, nil
 }
 
 func (u *userResourceType) Entitlements(ctx context.Context, resource *v2.Resource, token *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
@@ -171,15 +171,15 @@ func (u *userResourceType) CreateAccount(
 		"active":     "true",
 	}
 
-	createdUser, err := u.client.CreateUserAccount(ctx, user)
+	createdUser, annos, err := u.client.CreateUserAccount(ctx, user)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("baton-servicenow: failed to create user: %w", err)
+		return nil, nil, annos, fmt.Errorf("baton-servicenow: failed to create user: %w", err)
 	}
 
 	resource, err := userResource(createdUser)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("baton-servicenow: failed to create user resource: %w", err)
+		return nil, nil, annos, fmt.Errorf("baton-servicenow: failed to create user resource: %w", err)
 	}
 
-	return &v2.CreateAccountResponse_SuccessResult{Resource: resource}, nil, nil, nil
+	return &v2.CreateAccountResponse_SuccessResult{Resource: resource}, nil, annos, nil
 }

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -210,10 +210,10 @@ func (c *Client) GetUsers(ctx context.Context, paginationVars KeysetPaginationVa
 	return getKeysetPage(ctx, c, c.apiURL(UsersBaseUrl, c.deployment), reqOpts, func(u User) string { return u.Id })
 }
 
-func (c *Client) GetUser(ctx context.Context, userId string) (*User, error) {
+func (c *Client) GetUser(ctx context.Context, userId string) (*User, annotations.Annotations, error) {
 	var userResponse UserResponse
 
-	_, _, err := c.get(
+	_, annos, err := c.get(
 		ctx,
 		c.apiURL(UserBaseUrl, c.deployment, userId),
 		&userResponse,
@@ -221,10 +221,10 @@ func (c *Client) GetUser(ctx context.Context, userId string) (*User, error) {
 	)
 
 	if err != nil {
-		return nil, err
+		return nil, annos, err
 	}
 
-	return &userResponse.Result, nil
+	return &userResponse.Result, annos, nil
 }
 
 // Table sys_user_group (Groups).
@@ -234,10 +234,10 @@ func (c *Client) GetGroups(ctx context.Context, paginationVars KeysetPaginationV
 	return getKeysetPage(ctx, c, c.apiURL(GroupsBaseUrl, c.deployment), reqOpts, func(g Group) string { return g.Id })
 }
 
-func (c *Client) GetGroup(ctx context.Context, groupId string) (*Group, error) {
+func (c *Client) GetGroup(ctx context.Context, groupId string) (*Group, annotations.Annotations, error) {
 	var groupResponse GroupResponse
 
-	_, _, err := c.get(
+	_, annos, err := c.get(
 		ctx,
 		c.apiURL(GroupBaseUrl, c.deployment, groupId),
 		&groupResponse,
@@ -245,10 +245,10 @@ func (c *Client) GetGroup(ctx context.Context, groupId string) (*Group, error) {
 	)
 
 	if err != nil {
-		return nil, err
+		return nil, annos, err
 	}
 
-	return &groupResponse.Result, nil
+	return &groupResponse.Result, annos, nil
 }
 
 // Table sys_user_grmember (Group Members). When userId is empty
@@ -261,7 +261,7 @@ func (c *Client) GetUserToGroup(ctx context.Context, userId string, groupId stri
 	return getKeysetPage(ctx, c, c.apiURL(GroupMembersBaseUrl, c.deployment), reqOpts, func(m GroupMember) string { return m.Id })
 }
 
-func (c *Client) AddUserToGroup(ctx context.Context, record GroupMemberPayload) error {
+func (c *Client) AddUserToGroup(ctx context.Context, record GroupMemberPayload) (annotations.Annotations, error) {
 	return c.post(
 		ctx,
 		c.apiURL(GroupMembersBaseUrl, c.deployment),
@@ -271,7 +271,7 @@ func (c *Client) AddUserToGroup(ctx context.Context, record GroupMemberPayload) 
 	)
 }
 
-func (c *Client) RemoveUserFromGroup(ctx context.Context, id string) error {
+func (c *Client) RemoveUserFromGroup(ctx context.Context, id string) (annotations.Annotations, error) {
 	return c.delete(
 		ctx,
 		c.apiURL(GroupMemberDetailBaseUrl, c.deployment, id),
@@ -296,7 +296,7 @@ func (c *Client) GetUserToRole(ctx context.Context, userId string, roleId string
 	return getKeysetPage(ctx, c, c.apiURL(UserRolesBaseUrl, c.deployment), reqOpts, func(r UserToRole) string { return r.Id })
 }
 
-func (c *Client) GrantRoleToUser(ctx context.Context, record UserToRolePayload) error {
+func (c *Client) GrantRoleToUser(ctx context.Context, record UserToRolePayload) (annotations.Annotations, error) {
 	return c.post(
 		ctx,
 		c.apiURL(UserRolesBaseUrl, c.deployment),
@@ -306,7 +306,7 @@ func (c *Client) GrantRoleToUser(ctx context.Context, record UserToRolePayload) 
 	)
 }
 
-func (c *Client) RevokeRoleFromUser(ctx context.Context, id string) error {
+func (c *Client) RevokeRoleFromUser(ctx context.Context, id string) (annotations.Annotations, error) {
 	return c.delete(
 		ctx,
 		c.apiURL(UserRoleDetailBaseUrl, c.deployment, id),
@@ -322,7 +322,7 @@ func (c *Client) GetGroupToRole(ctx context.Context, groupId string, roleId stri
 	return getKeysetPage(ctx, c, c.apiURL(GroupRolesBaseUrl, c.deployment), reqOpts, func(r GroupToRole) string { return r.Id })
 }
 
-func (c *Client) GrantRoleToGroup(ctx context.Context, record GroupToRolePayload) error {
+func (c *Client) GrantRoleToGroup(ctx context.Context, record GroupToRolePayload) (annotations.Annotations, error) {
 	return c.post(
 		ctx,
 		c.apiURL(GroupRolesBaseUrl, c.deployment),
@@ -332,7 +332,7 @@ func (c *Client) GrantRoleToGroup(ctx context.Context, record GroupToRolePayload
 	)
 }
 
-func (c *Client) RevokeRoleFromGroup(ctx context.Context, id string) error {
+func (c *Client) RevokeRoleFromGroup(ctx context.Context, id string) (annotations.Annotations, error) {
 	return c.delete(
 		ctx,
 		c.apiURL(GroupRoleDetailBaseUrl, c.deployment, id),
@@ -370,8 +370,8 @@ func (c *Client) post(
 	resourceResponse interface{},
 	data interface{},
 	requestOptions ...ReqOpt,
-) error {
-	_, _, err := c.doRequestWithRetry(
+) (annotations.Annotations, error) {
+	_, annos, err := c.doRequestWithRetry(
 		ctx,
 		urlAddress,
 		http.MethodPost,
@@ -380,7 +380,7 @@ func (c *Client) post(
 		requestOptions...,
 	)
 
-	return err
+	return annos, err
 }
 
 func (c *Client) patch(
@@ -389,8 +389,8 @@ func (c *Client) patch(
 	resourceResponse interface{},
 	data interface{},
 	requestOptions ...ReqOpt,
-) error {
-	_, _, err := c.doRequestWithRetry(
+) (annotations.Annotations, error) {
+	_, annos, err := c.doRequestWithRetry(
 		ctx,
 		urlAddress,
 		http.MethodPatch,
@@ -399,7 +399,7 @@ func (c *Client) patch(
 		requestOptions...,
 	)
 
-	return err
+	return annos, err
 }
 
 func (c *Client) delete(
@@ -407,8 +407,8 @@ func (c *Client) delete(
 	urlAddress string,
 	resourceResponse interface{},
 	reqOptions ...ReqOpt,
-) error {
-	_, _, err := c.doRequestWithRetry(
+) (annotations.Annotations, error) {
+	_, annos, err := c.doRequestWithRetry(
 		ctx,
 		urlAddress,
 		http.MethodDelete,
@@ -417,7 +417,7 @@ func (c *Client) delete(
 		reqOptions...,
 	)
 
-	return err
+	return annos, err
 }
 
 // doRequest performs the request, decodes a successful JSON body into
@@ -505,14 +505,31 @@ func (c *Client) doHTTPRequest(ctx context.Context, urlAddress string, method st
 	annos.WithRateLimiting(&rlData)
 
 	if err != nil {
-		if rawResponse != nil && rawResponse.StatusCode >= 300 {
+		switch {
+		case rawResponse == nil:
+			// Transport-level failure -- no response to salvage.
+			return nil, annos, err
+
+		case rawResponse.StatusCode >= 300:
 			// Best-effort read: the body only enriches the message, so a
 			// read failure must not mask the status the caller needs. uhttp
 			// has already replaced Body with a re-readable buffer.
 			respBody, _ := io.ReadAll(rawResponse.Body)
 			return nil, annos, fmt.Errorf("request failed with status %d: %s: %w", rawResponse.StatusCode, string(respBody), err)
+
+		default:
+			// A 2xx with a non-nil error means a DoOption failed, not the
+			// request. The only option we pass is rate-limit extraction, which
+			// is advisory: ExtractRateLimitData runs strconv.ParseInt over the
+			// limit/remaining headers, so a non-numeric value ("unlimited")
+			// errors out. Failing a successfully fetched page over a header we
+			// only use for pacing would be strictly worse than ignoring it.
+			ctxzap.Extract(ctx).Warn(
+				"baton-servicenow: ignoring rate limit extraction failure on a successful response",
+				zap.Int("status_code", rawResponse.StatusCode),
+				zap.Error(err),
+			)
 		}
-		return nil, annos, err
 	}
 
 	if method != http.MethodDelete {
@@ -645,10 +662,10 @@ func withAuthRetry(ctx context.Context, urlAddress string, method string, attemp
 	return "", lastAnnos, lastErr
 }
 
-func (c *Client) CreateUserAccount(ctx context.Context, user any) (*User, error) {
+func (c *Client) CreateUserAccount(ctx context.Context, user any) (*User, annotations.Annotations, error) {
 	var response UserResponse
 
-	err := c.post(
+	annos, err := c.post(
 		ctx,
 		c.apiURL(UsersBaseUrl, c.deployment),
 		&response,
@@ -657,19 +674,19 @@ func (c *Client) CreateUserAccount(ctx context.Context, user any) (*User, error)
 	)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to create user in ServiceNow: %w", err)
+		return nil, annos, fmt.Errorf("failed to create user in ServiceNow: %w", err)
 	}
 
-	return &response.Result, nil
+	return &response.Result, annos, nil
 }
 
-func (c *Client) UpdateUserActiveStatus(ctx context.Context, userId string, active bool) (*User, error) {
+func (c *Client) UpdateUserActiveStatus(ctx context.Context, userId string, active bool) (*User, annotations.Annotations, error) {
 	payload := map[string]bool{
 		"active": active,
 	}
 
 	var response UserResponse
-	err := c.patch(
+	annos, err := c.patch(
 		ctx,
 		c.apiURL(UserBaseUrl, c.deployment, userId),
 		&response,
@@ -678,26 +695,26 @@ func (c *Client) UpdateUserActiveStatus(ctx context.Context, userId string, acti
 	)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to update user active status in ServiceNow: %w", err)
+		return nil, annos, fmt.Errorf("failed to update user active status in ServiceNow: %w", err)
 	}
 
-	return &response.Result, nil
+	return &response.Result, annos, nil
 }
 
 // Includes variables that come from variable sets (Table API -> item_option_new) and choices for those set variables.
-func (c *Client) GetCatalogItemVariablesPlusSets(ctx context.Context, itemSysID string) ([]CatalogItemVariable, error) {
-	itemVars, err := c.GetCatalogItemVariables(ctx, itemSysID)
+func (c *Client) GetCatalogItemVariablesPlusSets(ctx context.Context, itemSysID string) ([]CatalogItemVariable, annotations.Annotations, error) {
+	itemVars, annos, err := c.GetCatalogItemVariables(ctx, itemSysID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get item variables: %w", err)
+		return nil, annos, fmt.Errorf("failed to get item variables: %w", err)
 	}
 
 	// Find attached variable sets
-	links, _, err := c.GetVariableSetLinksForItem(ctx, itemSysID, PaginationVars{Limit: 200})
+	links, _, annos, err := c.GetVariableSetLinksForItem(ctx, itemSysID, PaginationVars{Limit: 200})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get variable set links: %w", err)
+		return nil, annos, fmt.Errorf("failed to get variable set links: %w", err)
 	}
 	if len(links) == 0 {
-		return itemVars, nil // nothing to add
+		return itemVars, annos, nil // nothing to add
 	}
 
 	setIDs := make([]string, 0, len(links))
@@ -706,9 +723,9 @@ func (c *Client) GetCatalogItemVariablesPlusSets(ctx context.Context, itemSysID 
 	}
 
 	// Fetch variables that belong to those sets
-	setVars, _, err := c.GetVariablesBySetIDs(ctx, setIDs, PaginationVars{Limit: 500})
+	setVars, _, annos, err := c.GetVariablesBySetIDs(ctx, setIDs, PaginationVars{Limit: 500})
 	if err != nil {
-		return nil, fmt.Errorf("failde to get variables by set ids: %w", err)
+		return nil, annos, fmt.Errorf("failde to get variables by set ids: %w", err)
 	}
 
 	// Fetch choices for set variables (so selects have options)
@@ -716,9 +733,9 @@ func (c *Client) GetCatalogItemVariablesPlusSets(ctx context.Context, itemSysID 
 	for _, v := range setVars {
 		varIDs = append(varIDs, v.SysID)
 	}
-	choices, _, err := c.GetChoicesForVariables(ctx, varIDs, PaginationVars{Limit: 1000})
+	choices, _, annos, err := c.GetChoicesForVariables(ctx, varIDs, PaginationVars{Limit: 1000})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get choices for set variables: %w", err)
+		return nil, annos, fmt.Errorf("failed to get choices for set variables: %w", err)
 	}
 	choicesByQ := make(map[string][]QuestionChoice, len(varIDs))
 	for _, ch := range choices {
@@ -744,10 +761,10 @@ func (c *Client) GetCatalogItemVariablesPlusSets(ctx context.Context, itemSysID 
 		}
 	}
 
-	return out, nil
+	return out, annos, nil
 }
 
-func (c *Client) GetVariableSetLinksForItem(ctx context.Context, itemSysID string, pg PaginationVars) ([]VariableSetM2M, string, error) {
+func (c *Client) GetVariableSetLinksForItem(ctx context.Context, itemSysID string, pg PaginationVars) ([]VariableSetM2M, string, annotations.Annotations, error) {
 	var resp VariableSetM2MResponse
 	req := []ReqOpt{
 		WithQueryParam("sysparm_query", fmt.Sprintf("sc_cat_item=%s", itemSysID)),
@@ -756,16 +773,16 @@ func (c *Client) GetVariableSetLinksForItem(ctx context.Context, itemSysID strin
 	}
 	req = append(req, paginationVarsToReqOptions(&pg)...)
 
-	next, _, err := c.get(ctx, c.apiURL(VariableSetM2MBaseUrl, c.deployment), &resp, req...)
+	next, annos, err := c.get(ctx, c.apiURL(VariableSetM2MBaseUrl, c.deployment), &resp, req...)
 	if err != nil {
-		return nil, "", err
+		return nil, "", annos, err
 	}
-	return resp.Result, next, nil
+	return resp.Result, next, annos, nil
 }
 
-func (c *Client) GetVariablesBySetIDs(ctx context.Context, setIDs []string, pg PaginationVars) ([]ItemOptionNew, string, error) {
+func (c *Client) GetVariablesBySetIDs(ctx context.Context, setIDs []string, pg PaginationVars) ([]ItemOptionNew, string, annotations.Annotations, error) {
 	if len(setIDs) == 0 {
-		return nil, "", nil
+		return nil, "", nil, nil
 	}
 	var resp ItemOptionNewResponse
 	req := []ReqOpt{
@@ -775,16 +792,16 @@ func (c *Client) GetVariablesBySetIDs(ctx context.Context, setIDs []string, pg P
 	}
 	req = append(req, paginationVarsToReqOptions(&pg)...)
 
-	next, _, err := c.get(ctx, c.apiURL(ItemOptionNewBaseUrl, c.deployment), &resp, req...)
+	next, annos, err := c.get(ctx, c.apiURL(ItemOptionNewBaseUrl, c.deployment), &resp, req...)
 	if err != nil {
-		return nil, "", err
+		return nil, "", annos, err
 	}
-	return resp.Result, next, nil
+	return resp.Result, next, annos, nil
 }
 
-func (c *Client) GetChoicesForVariables(ctx context.Context, varIDs []string, pg PaginationVars) ([]QuestionChoice, string, error) {
+func (c *Client) GetChoicesForVariables(ctx context.Context, varIDs []string, pg PaginationVars) ([]QuestionChoice, string, annotations.Annotations, error) {
 	if len(varIDs) == 0 {
-		return nil, "", nil
+		return nil, "", nil, nil
 	}
 	var resp QuestionChoiceResponse
 	req := []ReqOpt{
@@ -794,15 +811,15 @@ func (c *Client) GetChoicesForVariables(ctx context.Context, varIDs []string, pg
 	}
 	req = append(req, paginationVarsToReqOptions(&pg)...)
 
-	next, _, err := c.get(ctx, c.apiURL(QuestionChoiceBaseUrl, c.deployment), &resp, req...)
+	next, annos, err := c.get(ctx, c.apiURL(QuestionChoiceBaseUrl, c.deployment), &resp, req...)
 	if err != nil {
-		return nil, "", err
+		return nil, "", annos, err
 	}
-	return resp.Result, next, nil
+	return resp.Result, next, annos, nil
 }
 
 // Unused but consider switching to this to get both direct catalog item variables and variables from variable sets.
-func (c *Client) GetVariablesForItem(ctx context.Context, itemSysID string, pg PaginationVars) ([]ItemOptionNew, string, error) {
+func (c *Client) GetVariablesForItem(ctx context.Context, itemSysID string, pg PaginationVars) ([]ItemOptionNew, string, annotations.Annotations, error) {
 	var resp ItemOptionNewResponse
 	req := []ReqOpt{
 		WithQueryParam("sysparm_query", fmt.Sprintf("cat_item=%s", itemSysID)),
@@ -811,9 +828,9 @@ func (c *Client) GetVariablesForItem(ctx context.Context, itemSysID string, pg P
 	}
 	req = append(req, paginationVarsToReqOptions(&pg)...)
 
-	next, _, err := c.get(ctx, c.apiURL(ItemOptionNewBaseUrl, c.deployment), &resp, req...)
+	next, annos, err := c.get(ctx, c.apiURL(ItemOptionNewBaseUrl, c.deployment), &resp, req...)
 	if err != nil {
-		return nil, "", err
+		return nil, "", annos, err
 	}
-	return resp.Result, next, nil
+	return resp.Result, next, annos, nil
 }

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -4,15 +4,16 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/tomnomnom/linkheader"
 	"go.uber.org/zap"
@@ -105,7 +106,7 @@ type ItemOptionNewResponse = ListResponse[ItemOptionNew]
 type QuestionChoiceResponse = ListResponse[QuestionChoice]
 
 type Client struct {
-	httpClient          *http.Client
+	httpClient          *uhttp.BaseHttpClient
 	auth                string
 	deployment          string
 	baseURL             string
@@ -121,7 +122,7 @@ type Client struct {
 // https://developer.servicenow.com/dev.do#!/reference/api/yokohama/rest/c_TableAPI?navFilter=table .
 
 func NewClient(
-	httpClient *http.Client,
+	httpClient *uhttp.BaseHttpClient,
 	auth string,
 	deployment string,
 	ticketSchemaFilters map[string]string,
@@ -131,12 +132,30 @@ func NewClient(
 ) (*Client, error) {
 	var baseURL string
 	if baseURLOverride != "" {
+		// apiURL splices the override in as a URL prefix, so it has to be an
+		// absolute URL. url.Parse on its own accepts nearly any string, so the
+		// scheme/host check is what actually catches a misconfigured flag.
+		parsed, err := url.Parse(baseURLOverride)
+		if err != nil {
+			return nil, fmt.Errorf("invalid base URL %q: %w", baseURLOverride, err)
+		}
+		if parsed.Scheme == "" || parsed.Host == "" {
+			return nil, fmt.Errorf("invalid base URL %q: must include a scheme and host, e.g. https://example.service-now.com", baseURLOverride)
+		}
 		baseURL = baseURLOverride
 	} else {
 		var err error
 		baseURL, err = GenerateURL(InstanceURLTemplate, map[string]string{"Deployment": deployment})
 		if err != nil {
 			return nil, err
+		}
+		// Unlike the override, this one is a bare host (see
+		// InstanceURLTemplate) -- ticket.go composes it as
+		// url.URL{Scheme: "https", Host: baseURL}. Validate it as a host so a
+		// malformed deployment fails at startup instead of yielding a broken
+		// request URL mid-sync.
+		if parsed, err := url.Parse("https://" + baseURL); err != nil || parsed.Host != baseURL {
+			return nil, fmt.Errorf("invalid deployment %q: produced unusable instance host %q", deployment, baseURL)
 		}
 	}
 	return &Client{
@@ -171,19 +190,20 @@ func (c *Client) apiURL(pattern string, args ...any) string {
 // next seek token from the response. Uses c.getKeyset, not c.get: keyset
 // callers compute their own token via nextKeysetToken and don't need
 // doRequest's legacy Link-header token.
-func getKeysetPage[T any](ctx context.Context, c *Client, url string, reqOpts []ReqOpt, idFn func(T) string) ([]T, string, error) {
+func getKeysetPage[T any](ctx context.Context, c *Client, url string, reqOpts []ReqOpt, idFn func(T) string) ([]T, string, annotations.Annotations, error) {
 	var resp ListResponse[T]
-	if err := c.getKeyset(ctx, url, &resp, reqOpts...); err != nil {
-		return nil, "", err
+	annos, err := c.getKeyset(ctx, url, &resp, reqOpts...)
+	if err != nil {
+		return nil, "", annos, err
 	}
-	return resp.Result, nextKeysetToken(resp.Result, idFn), nil
+	return resp.Result, nextKeysetToken(resp.Result, idFn), annos, nil
 }
 
 // Table sys_user (Users). GetUsers always enumerates -- there's no
 // per-user provisioning variant -- so the domain filter and its page-size
 // cap (domainFilteredPageSize) always apply when AllowedDomains is
 // configured.
-func (c *Client) GetUsers(ctx context.Context, paginationVars KeysetPaginationVars) ([]User, string, error) {
+func (c *Client) GetUsers(ctx context.Context, paginationVars KeysetPaginationVars) ([]User, string, annotations.Annotations, error) {
 	paginationVars = cappedForDomainFilter("", c.AllowedDomains, paginationVars)
 	reqOpts := buildKeysetReqOptions(prepareUserFilters(c.AllowedDomains, c.CustomUserFields), &paginationVars)
 
@@ -193,7 +213,7 @@ func (c *Client) GetUsers(ctx context.Context, paginationVars KeysetPaginationVa
 func (c *Client) GetUser(ctx context.Context, userId string) (*User, error) {
 	var userResponse UserResponse
 
-	_, err := c.get(
+	_, _, err := c.get(
 		ctx,
 		c.apiURL(UserBaseUrl, c.deployment, userId),
 		&userResponse,
@@ -208,7 +228,7 @@ func (c *Client) GetUser(ctx context.Context, userId string) (*User, error) {
 }
 
 // Table sys_user_group (Groups).
-func (c *Client) GetGroups(ctx context.Context, paginationVars KeysetPaginationVars, groupIDs []string) ([]Group, string, error) {
+func (c *Client) GetGroups(ctx context.Context, paginationVars KeysetPaginationVars, groupIDs []string) ([]Group, string, annotations.Annotations, error) {
 	reqOpts := buildKeysetReqOptions(prepareGroupFilters(groupIDs), &paginationVars)
 
 	return getKeysetPage(ctx, c, c.apiURL(GroupsBaseUrl, c.deployment), reqOpts, func(g Group) string { return g.Id })
@@ -217,7 +237,7 @@ func (c *Client) GetGroups(ctx context.Context, paginationVars KeysetPaginationV
 func (c *Client) GetGroup(ctx context.Context, groupId string) (*Group, error) {
 	var groupResponse GroupResponse
 
-	_, err := c.get(
+	_, _, err := c.get(
 		ctx,
 		c.apiURL(GroupBaseUrl, c.deployment, groupId),
 		&groupResponse,
@@ -234,7 +254,7 @@ func (c *Client) GetGroup(ctx context.Context, groupId string) (*Group, error) {
 // Table sys_user_grmember (Group Members). When userId is empty
 // (enumeration), results are scoped to allowed-domains via user.email and
 // the page size is capped (see domainFilteredPageSize).
-func (c *Client) GetUserToGroup(ctx context.Context, userId string, groupId string, paginationVars KeysetPaginationVars) ([]GroupMember, string, error) {
+func (c *Client) GetUserToGroup(ctx context.Context, userId string, groupId string, paginationVars KeysetPaginationVars) ([]GroupMember, string, annotations.Annotations, error) {
 	paginationVars = cappedForDomainFilter(userId, c.AllowedDomains, paginationVars)
 	reqOpts := buildKeysetReqOptions(prepareUserToGroupFilter(userId, groupId, c.AllowedDomains), &paginationVars)
 
@@ -260,7 +280,7 @@ func (c *Client) RemoveUserFromGroup(ctx context.Context, id string) error {
 }
 
 // Table sys_user_role (Roles).
-func (c *Client) GetRoles(ctx context.Context, paginationVars KeysetPaginationVars) ([]Role, string, error) {
+func (c *Client) GetRoles(ctx context.Context, paginationVars KeysetPaginationVars) ([]Role, string, annotations.Annotations, error) {
 	reqOpts := buildKeysetReqOptions(prepareRoleFilters(), &paginationVars)
 
 	return getKeysetPage(ctx, c, c.apiURL(RolesBaseUrl, c.deployment), reqOpts, func(r Role) string { return r.Id })
@@ -269,7 +289,7 @@ func (c *Client) GetRoles(ctx context.Context, paginationVars KeysetPaginationVa
 // Table sys_user_has_role (User to Role). When userId is empty
 // (enumeration), results are scoped to allowed-domains via user.email and
 // the page size is capped (see domainFilteredPageSize).
-func (c *Client) GetUserToRole(ctx context.Context, userId string, roleId string, paginationVars KeysetPaginationVars) ([]UserToRole, string, error) {
+func (c *Client) GetUserToRole(ctx context.Context, userId string, roleId string, paginationVars KeysetPaginationVars) ([]UserToRole, string, annotations.Annotations, error) {
 	paginationVars = cappedForDomainFilter(userId, c.AllowedDomains, paginationVars)
 	reqOpts := buildKeysetReqOptions(prepareUserToRoleFilter(userId, roleId, c.AllowedDomains), &paginationVars)
 
@@ -296,7 +316,7 @@ func (c *Client) RevokeRoleFromUser(ctx context.Context, id string) error {
 
 // Table sys_group_has_role (Group to Role). No domain filter -- groups
 // don't have an email to scope by.
-func (c *Client) GetGroupToRole(ctx context.Context, groupId string, roleId string, paginationVars KeysetPaginationVars) ([]GroupToRole, string, error) {
+func (c *Client) GetGroupToRole(ctx context.Context, groupId string, roleId string, paginationVars KeysetPaginationVars) ([]GroupToRole, string, annotations.Annotations, error) {
 	reqOpts := buildKeysetReqOptions(prepareGroupToRoleFilter(groupId, roleId), &paginationVars)
 
 	return getKeysetPage(ctx, c, c.apiURL(GroupRolesBaseUrl, c.deployment), reqOpts, func(r GroupToRole) string { return r.Id })
@@ -320,7 +340,7 @@ func (c *Client) RevokeRoleFromGroup(ctx context.Context, id string) error {
 	)
 }
 
-func (c *Client) get(ctx context.Context, urlAddress string, resourceResponse interface{}, reqOptions ...ReqOpt) (string, error) {
+func (c *Client) get(ctx context.Context, urlAddress string, resourceResponse interface{}, reqOptions ...ReqOpt) (string, annotations.Annotations, error) {
 	return c.doRequestWithRetry(
 		ctx,
 		urlAddress,
@@ -333,7 +353,7 @@ func (c *Client) get(ctx context.Context, urlAddress string, resourceResponse in
 
 // getKeyset is like get but for keyset-paginated callers: it never computes
 // the legacy Link-header/X-Total-Count token, so it can't fail because of it.
-func (c *Client) getKeyset(ctx context.Context, urlAddress string, resourceResponse interface{}, reqOptions ...ReqOpt) error {
+func (c *Client) getKeyset(ctx context.Context, urlAddress string, resourceResponse interface{}, reqOptions ...ReqOpt) (annotations.Annotations, error) {
 	return c.doRequestWithRetryKeyset(
 		ctx,
 		urlAddress,
@@ -351,7 +371,7 @@ func (c *Client) post(
 	data interface{},
 	requestOptions ...ReqOpt,
 ) error {
-	_, err := c.doRequestWithRetry(
+	_, _, err := c.doRequestWithRetry(
 		ctx,
 		urlAddress,
 		http.MethodPost,
@@ -370,7 +390,7 @@ func (c *Client) patch(
 	data interface{},
 	requestOptions ...ReqOpt,
 ) error {
-	_, err := c.doRequestWithRetry(
+	_, _, err := c.doRequestWithRetry(
 		ctx,
 		urlAddress,
 		http.MethodPatch,
@@ -388,7 +408,7 @@ func (c *Client) delete(
 	resourceResponse interface{},
 	reqOptions ...ReqOpt,
 ) error {
-	_, err := c.doRequestWithRetry(
+	_, _, err := c.doRequestWithRetry(
 		ctx,
 		urlAddress,
 		http.MethodDelete,
@@ -400,66 +420,43 @@ func (c *Client) delete(
 	return err
 }
 
-func handleStatusCode(statusCode int) codes.Code {
-	switch statusCode {
-	case http.StatusRequestTimeout:
-		return codes.DeadlineExceeded
-	case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
-		return codes.Unavailable
-	case http.StatusNotFound:
-		return codes.NotFound
-	case http.StatusUnauthorized:
-		return codes.Unauthenticated
-	case http.StatusForbidden:
-		return codes.PermissionDenied
-	case http.StatusConflict:
-		return codes.AlreadyExists
-	case http.StatusNotImplemented:
-		return codes.Unimplemented
-	}
-
-	if statusCode >= 500 && statusCode <= 599 {
-		return codes.Unavailable
-	}
-
-	if statusCode < 200 || statusCode >= 300 {
-		return codes.Unknown
-	}
-
-	return codes.OK
-}
-
 // doRequest performs the request, decodes a successful JSON body into
 // resourceResponse, and returns the legacy Link-header/X-Total-Count
 // offset-pagination token used by Service Catalog/ticketing callers. Keyset
 // callers use doRequestKeyset instead.
-func (c *Client) doRequest(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (string, error) {
-	header, err := c.doHTTPRequest(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
+func (c *Client) doRequest(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (string, annotations.Annotations, error) {
+	header, annos, err := c.doHTTPRequest(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
 	if err != nil {
-		return "", err
+		return "", annos, err
 	}
-	return legacyOffsetToken(header)
+	token, err := legacyOffsetToken(header)
+	return token, annos, err
 }
 
 // doRequestKeyset is doRequest without the legacy Link-header/X-Total-Count
 // token computation. Keyset callers derive their own token from the decoded
 // body (nextKeysetToken), so a malformed Link header or non-numeric
 // sysparm_offset must not discard an otherwise successfully decoded page.
-func (c *Client) doRequestKeyset(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) error {
-	_, err := c.doHTTPRequest(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
-	return err
+func (c *Client) doRequestKeyset(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (annotations.Annotations, error) {
+	_, annos, err := c.doHTTPRequest(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
+	return annos, err
 }
 
-// doHTTPRequest sends the request and, for non-DELETE methods, decodes a
-// successful JSON body into resourceResponse. Returns only the response
-// headers, for callers that need to read pagination headers afterward.
-func (c *Client) doHTTPRequest(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (http.Header, error) {
+// doHTTPRequest sends the request through uhttp and, for non-DELETE methods,
+// decodes a successful JSON body into resourceResponse. Returns the response
+// headers (for callers that read pagination headers afterward) and the
+// rate-limit annotations extracted from the response.
+//
+// uhttp.BaseHttpClient.Do owns status-to-gRPC-code mapping
+// (uhttp.GrpcCodeFromHTTPStatus) and already attaches the rate-limit detail
+// to the error it returns, so there is no connector-local status table.
+func (c *Client) doHTTPRequest(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (http.Header, annotations.Annotations, error) {
 	var body io.Reader
 
 	if data != nil {
 		jsonBody, err := json.Marshal(data)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		body = bytes.NewBuffer(jsonBody)
@@ -467,7 +464,7 @@ func (c *Client) doHTTPRequest(ctx context.Context, urlAddress string, method st
 
 	req, err := http.NewRequestWithContext(ctx, method, urlAddress, body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Set default value
@@ -476,6 +473,11 @@ func (c *Client) doHTTPRequest(ctx context.Context, urlAddress string, method st
 	req.Header.Set("Authorization", c.auth)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	// uhttp caches GET 200s in memory for an hour by default
+	// (uhttp.DefaultCacheConfig). Identity and membership data must be read
+	// fresh on every sync -- a cached page would resurface deleted grants,
+	// so opt out rather than inherit the default.
+	req.Header.Set("Cache-Control", "no-cache")
 	if method == http.MethodPost || method == http.MethodPatch {
 		req.Header.Set("X-no-response-body", "true")
 	}
@@ -486,30 +488,40 @@ func (c *Client) doHTTPRequest(ctx context.Context, urlAddress string, method st
 
 	req.URL.RawQuery = req.URL.Query().Encode()
 
-	rawResponse, err := c.httpClient.Do(req)
-	if rawResponse != nil && rawResponse.Body != nil {
+	// Rate-limit data is captured for every response, success or failure.
+	// The success path is the one that matters: it lets the SDK's limiter
+	// pace upcoming requests and avoid the next 429, rather than only
+	// reacting once one has already been returned.
+	var rlData v2.RateLimitDescription
+	rawResponse, err := c.httpClient.Do(req, uhttp.WithRatelimitData(&rlData))
+	if rawResponse != nil {
+		// uhttp has already drained and closed the network body, swapping in
+		// an in-memory buffer, so this close is a no-op today. Kept nil-guarded
+		// and unconditional so the error path below can still read the body and
+		// the handling stays correct if uhttp's buffering ever changes.
 		defer rawResponse.Body.Close()
 	}
+	annos := annotations.Annotations{}
+	annos.WithRateLimiting(&rlData)
+
 	if err != nil {
-		return nil, err
-	}
-
-	if rawResponse.StatusCode < 0 || rawResponse.StatusCode > math.MaxUint32 {
-		return nil, errors.New("status code is out of range for uint32")
-	}
-
-	if rawResponse.StatusCode >= 300 {
-		respBody, _ := io.ReadAll(rawResponse.Body)
-		return nil, status.Errorf(handleStatusCode(rawResponse.StatusCode), "baton-servicenow: request failed with status %d: %s", rawResponse.StatusCode, string(respBody))
+		if rawResponse != nil && rawResponse.StatusCode >= 300 {
+			// Best-effort read: the body only enriches the message, so a
+			// read failure must not mask the status the caller needs. uhttp
+			// has already replaced Body with a re-readable buffer.
+			respBody, _ := io.ReadAll(rawResponse.Body)
+			return nil, annos, fmt.Errorf("request failed with status %d: %s: %w", rawResponse.StatusCode, string(respBody), err)
+		}
+		return nil, annos, err
 	}
 
 	if method != http.MethodDelete {
 		if err := json.NewDecoder(rawResponse.Body).Decode(&resourceResponse); err != nil {
-			return nil, err
+			return nil, annos, fmt.Errorf("decode %s response: %w", method, err)
 		}
 	}
 
-	return rawResponse.Header, nil
+	return rawResponse.Header, annos, nil
 }
 
 // legacyOffsetToken computes the Service Catalog/ticketing offset-pagination
@@ -552,8 +564,8 @@ const (
 
 // doRequestWithRetry wraps doRequest with a small retry loop for transient 401 responses.
 // On each 401 it logs the ServiceNow error body and waits an increasing delay before retrying.
-func (c *Client) doRequestWithRetry(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (string, error) {
-	return withAuthRetry(ctx, urlAddress, method, func() (string, error) {
+func (c *Client) doRequestWithRetry(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (string, annotations.Annotations, error) {
+	return withAuthRetry(ctx, urlAddress, method, func() (string, annotations.Annotations, error) {
 		return c.doRequest(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
 	})
 }
@@ -561,20 +573,25 @@ func (c *Client) doRequestWithRetry(ctx context.Context, urlAddress string, meth
 // doRequestWithRetryKeyset is doRequestWithRetry for keyset callers, routed
 // through doRequestKeyset instead of doRequest so a legacy-pagination-header
 // hiccup can't fail an otherwise successfully decoded page.
-func (c *Client) doRequestWithRetryKeyset(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) error {
-	_, err := withAuthRetry(ctx, urlAddress, method, func() (string, error) {
-		return "", c.doRequestKeyset(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
+func (c *Client) doRequestWithRetryKeyset(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (annotations.Annotations, error) {
+	_, annos, err := withAuthRetry(ctx, urlAddress, method, func() (string, annotations.Annotations, error) {
+		a, err := c.doRequestKeyset(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
+		return "", a, err
 	})
-	return err
+	return annos, err
 }
 
 // withAuthRetry retries attempt on transient 401 responses, logging the
 // retry/backoff around it. attempt returns whatever pagination token its
-// underlying request produces (keyset callers always pass "").
-func withAuthRetry(ctx context.Context, urlAddress string, method string, attempt func() (string, error)) (string, error) {
+// underlying request produces (keyset callers always pass "") plus the
+// rate-limit annotations, which are propagated from the final attempt --
+// including the failing one, so a caller that gives up still reports what
+// the last response said about the limit.
+func withAuthRetry(ctx context.Context, urlAddress string, method string, attempt func() (string, annotations.Annotations, error)) (string, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
 
 	var lastErr error
+	var lastAnnos annotations.Annotations
 	for try := 1; try <= maxAuthRetries+1; try++ {
 		if try > 1 {
 			delay := time.Duration(try-1) * authRetryBaseWait
@@ -588,11 +605,12 @@ func withAuthRetry(ctx context.Context, urlAddress string, method string, attemp
 			select {
 			case <-time.After(delay):
 			case <-ctx.Done():
-				return "", ctx.Err()
+				return "", lastAnnos, ctx.Err()
 			}
 		}
 
-		pageToken, err := attempt()
+		pageToken, annos, err := attempt()
+		lastAnnos = annos
 		if err == nil {
 			if try > 1 {
 				l.Debug("baton-servicenow: request succeeded after retry",
@@ -601,11 +619,11 @@ func withAuthRetry(ctx context.Context, urlAddress string, method string, attemp
 					zap.Int("attempt", try),
 				)
 			}
-			return pageToken, nil
+			return pageToken, annos, nil
 		}
 
 		if status.Code(err) != codes.Unauthenticated {
-			return "", err
+			return "", annos, err
 		}
 
 		l.Debug("baton-servicenow: received 401 unauthorized",
@@ -624,7 +642,7 @@ func withAuthRetry(ctx context.Context, urlAddress string, method string, attemp
 		zap.Int("max_attempts", maxAuthRetries+1),
 		zap.Error(lastErr),
 	)
-	return "", lastErr
+	return "", lastAnnos, lastErr
 }
 
 func (c *Client) CreateUserAccount(ctx context.Context, user any) (*User, error) {
@@ -738,7 +756,7 @@ func (c *Client) GetVariableSetLinksForItem(ctx context.Context, itemSysID strin
 	}
 	req = append(req, paginationVarsToReqOptions(&pg)...)
 
-	next, err := c.get(ctx, c.apiURL(VariableSetM2MBaseUrl, c.deployment), &resp, req...)
+	next, _, err := c.get(ctx, c.apiURL(VariableSetM2MBaseUrl, c.deployment), &resp, req...)
 	if err != nil {
 		return nil, "", err
 	}
@@ -757,7 +775,7 @@ func (c *Client) GetVariablesBySetIDs(ctx context.Context, setIDs []string, pg P
 	}
 	req = append(req, paginationVarsToReqOptions(&pg)...)
 
-	next, err := c.get(ctx, c.apiURL(ItemOptionNewBaseUrl, c.deployment), &resp, req...)
+	next, _, err := c.get(ctx, c.apiURL(ItemOptionNewBaseUrl, c.deployment), &resp, req...)
 	if err != nil {
 		return nil, "", err
 	}
@@ -776,7 +794,7 @@ func (c *Client) GetChoicesForVariables(ctx context.Context, varIDs []string, pg
 	}
 	req = append(req, paginationVarsToReqOptions(&pg)...)
 
-	next, err := c.get(ctx, c.apiURL(QuestionChoiceBaseUrl, c.deployment), &resp, req...)
+	next, _, err := c.get(ctx, c.apiURL(QuestionChoiceBaseUrl, c.deployment), &resp, req...)
 	if err != nil {
 		return nil, "", err
 	}
@@ -793,7 +811,7 @@ func (c *Client) GetVariablesForItem(ctx context.Context, itemSysID string, pg P
 	}
 	req = append(req, paginationVarsToReqOptions(&pg)...)
 
-	next, err := c.get(ctx, c.apiURL(ItemOptionNewBaseUrl, c.deployment), &resp, req...)
+	next, _, err := c.get(ctx, c.apiURL(ItemOptionNewBaseUrl, c.deployment), &resp, req...)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -534,6 +534,18 @@ func (c *Client) doHTTPRequest(ctx context.Context, urlAddress string, method st
 
 	if method != http.MethodDelete {
 		if err := json.NewDecoder(rawResponse.Body).Decode(&resourceResponse); err != nil {
+			// A hibernating ServiceNow instance answers 200 with an HTML
+			// page, and maintenance pages / WAF interstitials in front of a
+			// live one do the same. Decoding that as JSON yields "invalid
+			// character '<'", which tells an operator nothing about what is
+			// actually wrong. Only the message changes here -- the decode
+			// still has to fail first, so no working response is affected.
+			if contentType := rawResponse.Header.Get("Content-Type"); !uhttp.IsJSONContentType(contentType) {
+				return nil, annos, fmt.Errorf(
+					"expected a JSON response but got status %d with content-type %q -- the ServiceNow instance may be hibernating or behind an error page: %w",
+					rawResponse.StatusCode, contentType, err,
+				)
+			}
 			return nil, annos, fmt.Errorf("decode %s response: %w", method, err)
 		}
 	}

--- a/pkg/servicenow/client_test.go
+++ b/pkg/servicenow/client_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -154,6 +155,92 @@ func TestGetUsers_CapsPageSizeWhenDomainFilterApplies(t *testing.T) {
 	want := fmt.Sprintf("%d", domainFilteredPageSize)
 	if gotLimit != want {
 		t.Errorf("sysparm_limit sent = %q, want %q (AllowedDomains configured must cap the page size)", gotLimit, want)
+	}
+}
+
+// TestNonNumericRateLimitHeaderDoesNotFailA200 is a regression guard. uhttp
+// returns (resp[200], optionError) when a DoOption fails, and the only option
+// we pass is rate-limit extraction -- which runs strconv.ParseInt over the
+// limit/remaining headers, so a non-numeric value errors. Treating that as
+// fatal discarded a successfully fetched page over a header we only use for
+// pacing. Verified against a live instance: ServiceNow's Table API sends no
+// rate-limit headers at all on a 200, so this is reachable only once an
+// instance has a rate-limit rule configured -- which is exactly when we least
+// want the sync to fall over.
+func TestNonNumericRateLimitHeaderDoesNotFailA200(t *testing.T) {
+	for _, hv := range []string{"unlimited", "n/a", ""} {
+		t.Run("limit="+hv, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if hv != "" {
+					w.Header().Set("X-RateLimit-Limit", hv)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(ListResponse[Role]{Result: []Role{{BaseResource: BaseResource{Id: "role-000"}}}}); err != nil {
+					t.Errorf("failed to encode test response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			client, err := NewClient(uhttp.NewBaseHttpClient(server.Client()), "Basic dGVzdDp0ZXN0", "dev0", nil, nil, nil, server.URL)
+			if err != nil {
+				t.Fatalf("unexpected error creating client: %v", err)
+			}
+
+			roles, _, _, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50})
+			if err != nil {
+				t.Fatalf("an advisory rate-limit header must not fail the page: %v", err)
+			}
+			if len(roles) != 1 {
+				t.Errorf("roles len = %d, want 1 (the page must survive)", len(roles))
+			}
+		})
+	}
+}
+
+// TestWritesCarryRateLimitAnnotations covers the verbs behind provisioning.
+// post/patch/delete used to return only error, which structurally blocked every
+// grant, revoke, and account mutation from reporting rate-limit data.
+func TestWritesCarryRateLimitAnnotations(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "100")
+		w.Header().Set("X-RateLimit-Remaining", "3")
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(SingleResponse[BaseResource]{Result: BaseResource{Id: "x"}}); err != nil {
+			t.Errorf("failed to encode test response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(uhttp.NewBaseHttpClient(server.Client()), "Basic dGVzdDp0ZXN0", "dev0", nil, nil, nil, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+
+	cases := map[string]func() (annotations.Annotations, error){
+		"AddUserToGroup (post)": func() (annotations.Annotations, error) {
+			return client.AddUserToGroup(context.Background(), GroupMemberPayload{User: "u", Group: "g"})
+		},
+		"RemoveUserFromGroup (delete)": func() (annotations.Annotations, error) { return client.RemoveUserFromGroup(context.Background(), "id") },
+		"GrantRoleToUser (post)": func() (annotations.Annotations, error) {
+			return client.GrantRoleToUser(context.Background(), UserToRolePayload{User: "u", Role: "r"})
+		},
+		"RevokeRoleFromUser (delete)": func() (annotations.Annotations, error) { return client.RevokeRoleFromUser(context.Background(), "id") },
+	}
+
+	for name, call := range cases {
+		annos, err := call()
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", name, err)
+			continue
+		}
+		rl := &v2.RateLimitDescription{}
+		if ok, pErr := annos.Pick(rl); pErr != nil || !ok {
+			t.Errorf("%s: no RateLimitDescription annotation (ok=%v err=%v)", name, ok, pErr)
+			continue
+		}
+		if rl.GetRemaining() != 3 {
+			t.Errorf("%s: remaining = %d, want 3", name, rl.GetRemaining())
+		}
 	}
 }
 

--- a/pkg/servicenow/client_test.go
+++ b/pkg/servicenow/client_test.go
@@ -7,7 +7,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TestGetRoles_DoesNotTruncateOnShortNonEmptyPage guards against treating a
@@ -48,12 +55,12 @@ func TestGetRoles_DoesNotTruncateOnShortNonEmptyPage(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewClient(server.Client(), "Basic dGVzdDp0ZXN0", "dev0", nil, nil, nil, server.URL)
+	client, err := NewClient(uhttp.NewBaseHttpClient(server.Client()), "Basic dGVzdDp0ZXN0", "dev0", nil, nil, nil, server.URL)
 	if err != nil {
 		t.Fatalf("unexpected error creating client: %v", err)
 	}
 
-	page1, next1, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50})
+	page1, next1, _, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50})
 	if err != nil {
 		t.Fatalf("unexpected error on page 1: %v", err)
 	}
@@ -64,7 +71,7 @@ func TestGetRoles_DoesNotTruncateOnShortNonEmptyPage(t *testing.T) {
 		t.Fatalf("expected a non-empty next token after a full page")
 	}
 
-	page2, next2, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50, LastID: next1})
+	page2, next2, _, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50, LastID: next1})
 	if err != nil {
 		t.Fatalf("unexpected error on page 2: %v", err)
 	}
@@ -75,7 +82,7 @@ func TestGetRoles_DoesNotTruncateOnShortNonEmptyPage(t *testing.T) {
 		t.Fatalf("pagination stopped after a short-but-nonempty page (3 rows) while more rows remained")
 	}
 
-	page3, next3, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50, LastID: next2})
+	page3, next3, _, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50, LastID: next2})
 	if err != nil {
 		t.Fatalf("unexpected error on page 3: %v", err)
 	}
@@ -105,12 +112,12 @@ func TestGetRoles_IgnoresMalformedLegacyPaginationHeaders(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewClient(server.Client(), "Basic dGVzdDp0ZXN0", "dev0", nil, nil, nil, server.URL)
+	client, err := NewClient(uhttp.NewBaseHttpClient(server.Client()), "Basic dGVzdDp0ZXN0", "dev0", nil, nil, nil, server.URL)
 	if err != nil {
 		t.Fatalf("unexpected error creating client: %v", err)
 	}
 
-	roles, _, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50})
+	roles, _, _, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50})
 	if err != nil {
 		t.Fatalf("unexpected error: %v (a malformed legacy pagination header must not fail a keyset page fetch)", err)
 	}
@@ -134,12 +141,12 @@ func TestGetUsers_CapsPageSizeWhenDomainFilterApplies(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewClient(server.Client(), "Basic dGVzdDp0ZXN0", "dev0", nil, []string{"draftkings.com"}, nil, server.URL)
+	client, err := NewClient(uhttp.NewBaseHttpClient(server.Client()), "Basic dGVzdDp0ZXN0", "dev0", nil, []string{"draftkings.com"}, nil, server.URL)
 	if err != nil {
 		t.Fatalf("unexpected error creating client: %v", err)
 	}
 
-	_, _, err = client.GetUsers(context.Background(), KeysetPaginationVars{Limit: 200})
+	_, _, _, err = client.GetUsers(context.Background(), KeysetPaginationVars{Limit: 200})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -147,5 +154,262 @@ func TestGetUsers_CapsPageSizeWhenDomainFilterApplies(t *testing.T) {
 	want := fmt.Sprintf("%d", domainFilteredPageSize)
 	if gotLimit != want {
 		t.Errorf("sysparm_limit sent = %q, want %q (AllowedDomains configured must cap the page size)", gotLimit, want)
+	}
+}
+
+// TestNewClientValidatesBaseURL covers both URL shapes the constructor
+// produces: the override is an absolute URL spliced in by apiURL, while the
+// deployment-derived value is a bare host that ticket.go composes into
+// url.URL{Scheme: "https", Host: ...}. Either being malformed used to surface
+// only as a confusing failure on the first request.
+func TestNewClientValidatesBaseURL(t *testing.T) {
+	cases := []struct {
+		name       string
+		deployment string
+		override   string
+		wantErr    bool
+	}{
+		{"valid override", "dev0", "https://example.service-now.com", false},
+		{"valid override with port", "dev0", "http://127.0.0.1:8080", false},
+		{"override missing scheme", "dev0", "example.service-now.com", true},
+		{"override missing host", "dev0", "https://", true},
+		{"valid deployment", "dev0", "", false},
+		{"deployment with a space", "dev 0", "", true},
+		{"deployment with a slash", "a/b", "", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewClient(nil, "Basic dGVzdDp0ZXN0", tc.deployment, nil, nil, nil, tc.override)
+			if tc.wantErr && err == nil {
+				t.Errorf("deployment=%q override=%q: want an error at construction, got nil", tc.deployment, tc.override)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("deployment=%q override=%q: unexpected error %v", tc.deployment, tc.override, err)
+			}
+		})
+	}
+}
+
+// TestAuthRetryRecoversFrom401 guards withAuthRetry against the error-plumbing
+// change underneath it: the retry only fires if status.Code() still resolves to
+// Unauthenticated, which now means resolving *through* uhttp's wrapped error and
+// the fmt.Errorf("%w") around it. A regression here is silent -- the sync would
+// simply fail on a transient 401 instead of retrying.
+func TestAuthRetryRecoversFrom401(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if err := json.NewEncoder(w).Encode(ListResponse[Role]{Result: []Role{{BaseResource: BaseResource{Id: "role-000"}}}}); err != nil {
+			t.Errorf("failed to encode test response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(uhttp.NewBaseHttpClient(server.Client()), "Basic dGVzdDp0ZXN0", "dev0", nil, nil, nil, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+
+	roles, _, _, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50})
+	if err != nil {
+		t.Fatalf("expected recovery after a transient 401, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("server saw %d call(s), want 2 (the 401 must be retried once)", got)
+	}
+	if len(roles) != 1 {
+		t.Errorf("roles len = %d, want 1", len(roles))
+	}
+}
+
+// TestSuccessfulResponseCarriesRateLimitAnnotations covers the half of the
+// contract that actually prevents a 429: rate-limit headers on a *successful*
+// response must reach the SDK as annotations, so its limiter can pace the
+// next request. Reacting only to 429s (the error path) is strictly worse --
+// by then the request has already been rejected.
+func TestSuccessfulResponseCarriesRateLimitAnnotations(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "100")
+		w.Header().Set("X-RateLimit-Remaining", "7")
+		w.Header().Set("X-RateLimit-Reset", "30")
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(ListResponse[Role]{Result: []Role{{BaseResource: BaseResource{Id: "role-000"}}}}); err != nil {
+			t.Errorf("failed to encode test response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(uhttp.NewBaseHttpClient(server.Client()), "Basic dGVzdDp0ZXN0", "dev0", nil, nil, nil, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+
+	roles, _, annos, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(roles) != 1 {
+		t.Fatalf("roles len = %d, want 1", len(roles))
+	}
+
+	rl := &v2.RateLimitDescription{}
+	if ok, err := annos.Pick(rl); err != nil || !ok {
+		t.Fatalf("no RateLimitDescription annotation on a successful response (ok=%v, err=%v); the SDK limiter has nothing to pace with", ok, err)
+	}
+	if rl.GetLimit() != 100 {
+		t.Errorf("limit = %d, want 100", rl.GetLimit())
+	}
+	if rl.GetRemaining() != 7 {
+		t.Errorf("remaining = %d, want 7", rl.GetRemaining())
+	}
+}
+
+// TestRequestsOptOutOfUhttpCache pins a behavioural decision that is invisible
+// at the call site: uhttp.BaseHttpClient caches GET 200s in memory for an hour
+// by default. Identity and membership listings must be read fresh on every
+// sync -- a cached page would resurface grants that have since been revoked.
+func TestRequestsOptOutOfUhttpCache(t *testing.T) {
+	var gotCacheControl string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCacheControl = r.Header.Get("Cache-Control")
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(ListResponse[Role]{Result: nil}); err != nil {
+			t.Errorf("failed to encode test response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(uhttp.NewBaseHttpClient(server.Client()), "Basic dGVzdDp0ZXN0", "dev0", nil, nil, nil, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+
+	if _, _, _, err = client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotCacheControl != "no-cache" {
+		t.Errorf("Cache-Control = %q, want %q (uhttp would otherwise serve hour-old sync data)", gotCacheControl, "no-cache")
+	}
+}
+
+// TestErrorCarriesRateLimitDescription guards the contract the SDK retryer
+// depends on: a throttled response must surface a v2.RateLimitDescription as
+// a gRPC status detail, and it must survive the caller-side fmt.Errorf("%w")
+// wrapping every builder applies. Without the detail the retryer falls back
+// to blind linear backoff and ignores ServiceNow's Retry-After entirely
+// (see baton-sdk pkg/retry/retry.go).
+func TestErrorCarriesRateLimitDescription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "42")
+		w.Header().Set("X-RateLimit-Limit", "100")
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(uhttp.NewBaseHttpClient(server.Client()), "Basic dGVzdDp0ZXN0", "dev0", nil, nil, nil, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+
+	_, _, _, err = client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50})
+	if err == nil {
+		t.Fatalf("expected an error on a 429 response")
+	}
+
+	// Mirror what the resource builders do to the client's error.
+	wrapped := fmt.Errorf("baton-servicenow: failed to list roles: %w", err)
+
+	if code := status.Code(wrapped); code != codes.Unavailable {
+		t.Errorf("status code = %v, want %v (the SDK retryer only retries Unavailable/DeadlineExceeded)", code, codes.Unavailable)
+	}
+
+	st, ok := status.FromError(wrapped)
+	if !ok {
+		t.Fatalf("wrapped error did not resolve to a gRPC status")
+	}
+
+	var rl *v2.RateLimitDescription
+	for _, detail := range st.Details() {
+		if d, ok := detail.(*v2.RateLimitDescription); ok {
+			rl = d
+			break
+		}
+	}
+	if rl == nil {
+		t.Fatalf("no RateLimitDescription detail on the error; the SDK retryer will use blind backoff")
+	}
+
+	if rl.GetStatus() != v2.RateLimitDescription_STATUS_OVERLIMIT {
+		t.Errorf("rate limit status = %v, want STATUS_OVERLIMIT", rl.GetStatus())
+	}
+	if rl.GetRemaining() != 0 {
+		t.Errorf("remaining = %d, want 0", rl.GetRemaining())
+	}
+	// Retry-After: 42 is a relative offset, so ResetAt lands ~42s out.
+	if wait := time.Until(rl.GetResetAt().AsTime()); wait < 30*time.Second || wait > 45*time.Second {
+		t.Errorf("ResetAt is %v out, want ~42s (Retry-After must drive the backoff)", wait)
+	}
+}
+
+// TestErrorCarriesRateLimitDescription_NoHeaders is the case the whole change
+// rests on: we have not confirmed that ServiceNow actually emits rate-limit
+// headers, and it doesn't matter. ExtractRateLimitData synthesizes
+// STATUS_OVERLIMIT + a 60s reset for any bare 429 (baton-sdk
+// pkg/ratelimit/http.go), which is what lets the retryer skip its 1s/2s/3s
+// ramp. If this stops holding, the change silently loses its value on an
+// instance that sends no headers.
+func TestErrorCarriesRateLimitDescription_NoHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests) // no rate-limit headers whatsoever
+	}))
+	defer server.Close()
+
+	client, err := NewClient(uhttp.NewBaseHttpClient(server.Client()), "Basic dGVzdDp0ZXN0", "dev0", nil, nil, nil, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+
+	_, _, _, err = client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50})
+	if err == nil {
+		t.Fatalf("expected an error on a 429 response")
+	}
+
+	st, ok := status.FromError(fmt.Errorf("baton-servicenow: failed to list roles: %w", err))
+	if !ok {
+		t.Fatalf("wrapped error did not resolve to a gRPC status")
+	}
+
+	var rl *v2.RateLimitDescription
+	for _, detail := range st.Details() {
+		if d, ok := detail.(*v2.RateLimitDescription); ok {
+			rl = d
+			break
+		}
+	}
+	if rl == nil {
+		t.Fatalf("no RateLimitDescription detail on a header-less 429")
+	}
+
+	// STATUS_OVERLIMIT is also what flags the failure as rate limiting in
+	// baton-sdk pkg/metrics/instrumentor.go.
+	if rl.GetStatus() != v2.RateLimitDescription_STATUS_OVERLIMIT {
+		t.Errorf("status = %v, want STATUS_OVERLIMIT even with no headers", rl.GetStatus())
+	}
+	// remaining <= 0 and a future ResetAt are jointly what make the retryer
+	// take the rate-limit branch instead of linear backoff.
+	if rl.GetRemaining() > 0 {
+		t.Errorf("remaining = %d, want <= 0 so the retryer waits until reset", rl.GetRemaining())
+	}
+	if wait := time.Until(rl.GetResetAt().AsTime()); wait < 45*time.Second || wait > 65*time.Second {
+		t.Errorf("ResetAt is %v out, want the synthesized ~60s fallback", wait)
 	}
 }

--- a/pkg/servicenow/client_test.go
+++ b/pkg/servicenow/client_test.go
@@ -244,6 +244,39 @@ func TestWritesCarryRateLimitAnnotations(t *testing.T) {
 	}
 }
 
+// TestNonJSONResponseNamesTheActualProblem covers the shape a hibernating
+// ServiceNow PDI returns: HTTP 200 with an HTML page. Decoding that as JSON
+// produces "invalid character '<' looking for beginning of value", which sent
+// two engineers looking for a connector bug when the instance was simply
+// asleep. The error must say so.
+func TestNonJSONResponseNamesTheActualProblem(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("<!DOCTYPE html><html><body>This instance is hibernating</body></html>")); err != nil {
+			t.Errorf("failed to write test response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(uhttp.NewBaseHttpClient(server.Client()), "Basic dGVzdDp0ZXN0", "dev0", nil, nil, nil, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+
+	_, _, _, err = client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50})
+	if err == nil {
+		t.Fatalf("expected an error decoding an HTML body")
+	}
+
+	msg := err.Error()
+	for _, want := range []string{"hibernating", "text/html", "status 200"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q; got: %s", want, msg)
+		}
+	}
+}
+
 // TestNewClientValidatesBaseURL covers both URL shapes the constructor
 // produces: the override is an absolute URL spliced in by apiURL, while the
 // deployment-derived value is a bare host that ticket.go composes into

--- a/pkg/servicenow/service_catalog_request.go
+++ b/pkg/servicenow/service_catalog_request.go
@@ -4,9 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 )
 
 var ErrLabelNotFound = errors.New("label not found")
+
+// Note on multi-call methods below: annotations carry at most one
+// RateLimitDescription (annotations.WithRateLimiting uses Update, which
+// replaces by type), and annotations.Merge appends rather than replaces -- two
+// merged bags would leave Pick returning the stale entry. So methods that issue
+// several requests return the annotations from the *last* one, which reflects
+// the most recent state of the limit.
 
 type FieldOption func(catalogItemRequestPayload *OrderItemPayload)
 
@@ -19,52 +28,52 @@ func WithCustomField(id string, value interface{}) FieldOption {
 	}
 }
 
-func (c *Client) GetServiceCatalogRequest(ctx context.Context, requestId string) (*ServiceCatalogRequest, error) {
+func (c *Client) GetServiceCatalogRequest(ctx context.Context, requestId string) (*ServiceCatalogRequest, annotations.Annotations, error) {
 	var serviceCatalogRequestResponse ServiceCatalogRequestResponse
-	_, _, err := c.get(
+	_, annos, err := c.get(
 		ctx,
 		c.apiURL(ServiceCatalogRequestDetailsBaseUrl, c.deployment, requestId),
 		&serviceCatalogRequestResponse,
 		WithIncludeExternalRefLink(),
 	)
 	if err != nil {
-		return nil, err
+		return nil, annos, err
 	}
-	return &serviceCatalogRequestResponse.Result, nil
+	return &serviceCatalogRequestResponse.Result, annos, nil
 }
 
-func (c *Client) GetServiceCatalogRequestItem(ctx context.Context, requestItemId string) (*RequestedItem, error) {
+func (c *Client) GetServiceCatalogRequestItem(ctx context.Context, requestItemId string) (*RequestedItem, annotations.Annotations, error) {
 	var requestItemResponse RequestItemResponse
-	_, _, err := c.get(
+	_, annos, err := c.get(
 		ctx,
 		c.apiURL(ServiceCatalogRequestedItemDetailsBaseUrl, c.deployment, requestItemId),
 		&requestItemResponse,
 		WithIncludeExternalRefLink(),
 	)
 	if err != nil {
-		return nil, err
+		return nil, annos, err
 	}
-	return &requestItemResponse.Result, nil
+	return &requestItemResponse.Result, annos, nil
 }
 
-func (c *Client) GetServiceCatalogRequestedItemForRequest(ctx context.Context, serviceCatalogRequestId string) (*RequestedItem, error) {
-	requestItemsResponse, _, err := c.GetServiceCatalogRequestItems(ctx,
+func (c *Client) GetServiceCatalogRequestedItemForRequest(ctx context.Context, serviceCatalogRequestId string) (*RequestedItem, annotations.Annotations, error) {
+	requestItemsResponse, _, annos, err := c.GetServiceCatalogRequestItems(ctx,
 		WithPageLimit(1),
 		WithQuery(fmt.Sprintf("request=%s", serviceCatalogRequestId)),
 		WithIncludeExternalRefLink(),
 	)
 	if err != nil {
-		return nil, err
+		return nil, annos, err
 	}
 	if len(requestItemsResponse) == 0 {
-		return nil, errors.New("no request item found for request")
+		return nil, annos, errors.New("no request item found for request")
 	}
-	return &requestItemsResponse[0], nil
+	return &requestItemsResponse[0], annos, nil
 }
 
-func (c *Client) UpdateServiceCatalogRequestItem(ctx context.Context, requestItemId string, payload *RequestedItemUpdatePayload) (*RequestedItem, error) {
+func (c *Client) UpdateServiceCatalogRequestItem(ctx context.Context, requestItemId string, payload *RequestedItemUpdatePayload) (*RequestedItem, annotations.Annotations, error) {
 	var requestItemResponse RequestItemResponse
-	err := c.patch(
+	annos, err := c.patch(
 		ctx,
 		c.apiURL(ServiceCatalogRequestedItemDetailsBaseUrl, c.deployment, requestItemId),
 		&requestItemResponse,
@@ -73,26 +82,26 @@ func (c *Client) UpdateServiceCatalogRequestItem(ctx context.Context, requestIte
 		WithIncludeExternalRefLink(),
 	)
 	if err != nil {
-		return nil, err
+		return nil, annos, err
 	}
-	return &requestItemResponse.Result, nil
+	return &requestItemResponse.Result, annos, nil
 }
 
-func (c *Client) GetServiceCatalogRequestItems(ctx context.Context, reqOptions ...ReqOpt) ([]RequestedItem, string, error) {
+func (c *Client) GetServiceCatalogRequestItems(ctx context.Context, reqOptions ...ReqOpt) ([]RequestedItem, string, annotations.Annotations, error) {
 	var requestItemsResponse RequestItemsResponse
-	nextPageToken, _, err := c.get(
+	nextPageToken, annos, err := c.get(
 		ctx,
 		c.apiURL(ServiceCatalogRequestedItemBaseUrl, c.deployment),
 		&requestItemsResponse,
 		reqOptions...,
 	)
 	if err != nil {
-		return nil, "", err
+		return nil, "", annos, err
 	}
-	return requestItemsResponse.Result, nextPageToken, nil
+	return requestItemsResponse.Result, nextPageToken, annos, nil
 }
 
-func (c *Client) GetCatalogItems(ctx context.Context, paginationVars *PaginationVars) ([]CatalogItem, string, error) {
+func (c *Client) GetCatalogItems(ctx context.Context, paginationVars *PaginationVars) ([]CatalogItem, string, annotations.Annotations, error) {
 	var catalogItemsResponse CatalogItemsResponse
 	reqOpts := []ReqOpt{
 		WithPageLimit(paginationVars.Limit),
@@ -101,62 +110,62 @@ func (c *Client) GetCatalogItems(ctx context.Context, paginationVars *Pagination
 	for k, v := range c.TicketSchemaFilters {
 		reqOpts = append(reqOpts, WithQueryParam(k, v))
 	}
-	nextPageToken, _, err := c.get(
+	nextPageToken, annos, err := c.get(
 		ctx,
 		c.apiURL(ServiceCatalogItemBaseUrl, c.deployment),
 		&catalogItemsResponse,
 		reqOpts...,
 	)
 	if err != nil {
-		return nil, "", err
+		return nil, "", annos, err
 	}
-	return catalogItemsResponse.Result, nextPageToken, nil
+	return catalogItemsResponse.Result, nextPageToken, annos, nil
 }
 
-func (c *Client) GetCatalogItem(ctx context.Context, catalogItemId string) (*CatalogItem, error) {
+func (c *Client) GetCatalogItem(ctx context.Context, catalogItemId string) (*CatalogItem, annotations.Annotations, error) {
 	var catalogItemResponse CatalogItemResponse
-	_, _, err := c.get(
+	_, annos, err := c.get(
 		ctx,
 		c.apiURL(ServiceCatalogItemGetUrl, c.deployment, catalogItemId),
 		&catalogItemResponse,
 	)
 	if err != nil {
-		return nil, err
+		return nil, annos, err
 	}
-	return &catalogItemResponse.Result, nil
+	return &catalogItemResponse.Result, annos, nil
 }
 
-func (c *Client) GetCatalogItemVariables(ctx context.Context, catalogItemId string) ([]CatalogItemVariable, error) {
+func (c *Client) GetCatalogItemVariables(ctx context.Context, catalogItemId string) ([]CatalogItemVariable, annotations.Annotations, error) {
 	var catalogItemVariablesResponse CatalogItemVariablesResponse
-	_, _, err := c.get(
+	_, annos, err := c.get(
 		ctx,
 		c.apiURL(ServiceCatalogItemVariablesUrl, c.deployment, catalogItemId),
 		&catalogItemVariablesResponse,
 	)
 	if err != nil {
-		return nil, err
+		return nil, annos, err
 	}
-	return catalogItemVariablesResponse.Result, nil
+	return catalogItemVariablesResponse.Result, annos, nil
 }
 
 // Creating a service catalog request requires:
 // 1. Add catalog item to cart (with all required variables).
 // 2. Submit cart order.
-func (c *Client) CreateServiceCatalogRequest(ctx context.Context, catalogItemId string, payload *OrderItemPayload) (*RequestedItem, error) {
-	requestInfo, err := c.OrderItemNow(ctx, catalogItemId, payload)
+func (c *Client) CreateServiceCatalogRequest(ctx context.Context, catalogItemId string, payload *OrderItemPayload) (*RequestedItem, annotations.Annotations, error) {
+	requestInfo, annos, err := c.OrderItemNow(ctx, catalogItemId, payload)
 	if err != nil {
-		return nil, err
+		return nil, annos, err
 	}
-	requestItem, err := c.GetServiceCatalogRequestedItemForRequest(ctx, requestInfo.RequestID)
+	requestItem, annos, err := c.GetServiceCatalogRequestedItemForRequest(ctx, requestInfo.RequestID)
 	if err != nil {
-		return nil, err
+		return nil, annos, err
 	}
-	return requestItem, nil
+	return requestItem, annos, nil
 }
 
-func (c *Client) OrderItemNow(ctx context.Context, catalogItemId string, payload *OrderItemPayload) (*RequestInfo, error) {
+func (c *Client) OrderItemNow(ctx context.Context, catalogItemId string, payload *OrderItemPayload) (*RequestInfo, annotations.Annotations, error) {
 	var orderCatalogItemResponse OrderCatalogItemResponse
-	err := c.post(
+	annos, err := c.post(
 		ctx,
 		c.apiURL(ServiceCatalogOrderItemUrl, c.deployment, catalogItemId),
 		&orderCatalogItemResponse,
@@ -164,32 +173,34 @@ func (c *Client) OrderItemNow(ctx context.Context, catalogItemId string, payload
 		WithIncludeResponseBody(),
 	)
 	if err != nil {
-		return nil, err
+		return nil, annos, err
 	}
-	return &orderCatalogItemResponse.Result, nil
+	return &orderCatalogItemResponse.Result, annos, nil
 }
 
-func (c *Client) AddLabelsToRequest(ctx context.Context, requestedItemId string, labels []string) error {
+func (c *Client) AddLabelsToRequest(ctx context.Context, requestedItemId string, labels []string) (annotations.Annotations, error) {
+	var annos annotations.Annotations
 	for _, label := range labels {
-		_, err := c.AddLabelToRequest(ctx, requestedItemId, label)
+		_, labelAnnos, err := c.AddLabelToRequest(ctx, requestedItemId, label)
+		annos = labelAnnos
 		if err != nil {
-			return err
+			return annos, err
 		}
 	}
-	return nil
+	return annos, nil
 }
 
-func (c *Client) AddLabelToRequest(ctx context.Context, requestedItemId string, label string) (*BaseResource, error) {
-	labelResp, err := c.CreateLabel(ctx, label)
+func (c *Client) AddLabelToRequest(ctx context.Context, requestedItemId string, label string) (*BaseResource, annotations.Annotations, error) {
+	labelResp, annos, err := c.CreateLabel(ctx, label)
 	if err != nil {
-		return nil, err
+		return nil, annos, err
 	}
 	return c.addLabelToRequestedItem(ctx, requestedItemId, labelResp.Id)
 }
 
-func (c *Client) addLabelToRequestedItem(ctx context.Context, requestedItemId string, labelId string) (*BaseResource, error) {
+func (c *Client) addLabelToRequestedItem(ctx context.Context, requestedItemId string, labelId string) (*BaseResource, annotations.Annotations, error) {
 	var labelEntryResponse IDResponse
-	err := c.post(
+	annos, err := c.post(
 		ctx,
 		c.apiURL(LabelEntryBaseUrl, c.deployment),
 		&labelEntryResponse,
@@ -201,44 +212,44 @@ func (c *Client) addLabelToRequestedItem(ctx context.Context, requestedItemId st
 		WithIncludeResponseBody(),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error adding label %s to requested item %s: %w", labelId, requestedItemId, err)
+		return nil, annos, fmt.Errorf("error adding label %s to requested item %s: %w", labelId, requestedItemId, err)
 	}
-	return &labelEntryResponse.Result, nil
+	return &labelEntryResponse.Result, annos, nil
 }
 
 // Create label will return an error if it already exists.
 // First fetch the label to check if it already exists.
-func (c *Client) CreateLabel(ctx context.Context, label string) (*Label, error) {
-	labelResp, err := c.GetLabel(ctx, label)
+func (c *Client) CreateLabel(ctx context.Context, label string) (*Label, annotations.Annotations, error) {
+	labelResp, annos, err := c.GetLabel(ctx, label)
 	if err == nil {
-		return labelResp, nil
+		return labelResp, annos, nil
 	}
 	if errors.Is(err, ErrLabelNotFound) {
 		return c.createLabel(ctx, label)
 	}
-	return nil, err
+	return nil, annos, err
 }
 
-func (c *Client) GetLabel(ctx context.Context, label string) (*Label, error) {
+func (c *Client) GetLabel(ctx context.Context, label string) (*Label, annotations.Annotations, error) {
 	var labelsResponse LabelsResponse
-	_, _, err := c.get(
+	_, annos, err := c.get(
 		ctx,
 		c.apiURL(LabelBaseUrl, c.deployment),
 		&labelsResponse,
 		WithQuery(fmt.Sprintf("name=%s", label)),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching label '%s': %w", label, err)
+		return nil, annos, fmt.Errorf("error fetching label '%s': %w", label, err)
 	}
 	if len(labelsResponse.Result) == 0 {
-		return nil, ErrLabelNotFound
+		return nil, annos, ErrLabelNotFound
 	}
-	return &labelsResponse.Result[0], nil
+	return &labelsResponse.Result[0], annos, nil
 }
 
-func (c *Client) createLabel(ctx context.Context, label string) (*Label, error) {
+func (c *Client) createLabel(ctx context.Context, label string) (*Label, annotations.Annotations, error) {
 	var labelResponse LabelResponse
-	err := c.post(
+	annos, err := c.post(
 		ctx,
 		c.apiURL(LabelBaseUrl, c.deployment),
 		&labelResponse,
@@ -249,14 +260,14 @@ func (c *Client) createLabel(ctx context.Context, label string) (*Label, error) 
 		WithIncludeResponseBody(),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error creating label '%s': %w", label, err)
+		return nil, annos, fmt.Errorf("error creating label '%s': %w", label, err)
 	}
-	return &labelResponse.Result, nil
+	return &labelResponse.Result, annos, nil
 }
 
-func (c *Client) GetLabelsForRequestedItem(ctx context.Context, requestedItemId string) ([]string, error) {
+func (c *Client) GetLabelsForRequestedItem(ctx context.Context, requestedItemId string) ([]string, annotations.Annotations, error) {
 	var labelResponse LabelEntriesLabelNameResponse
-	_, _, err := c.get(
+	_, annos, err := c.get(
 		ctx,
 		c.apiURL(LabelEntryBaseUrl, c.deployment),
 		&labelResponse,
@@ -264,18 +275,18 @@ func (c *Client) GetLabelsForRequestedItem(ctx context.Context, requestedItemId 
 		WithFields("label.name"),
 	)
 	if err != nil {
-		return nil, err
+		return nil, annos, err
 	}
 	labelStrings := make([]string, 0, len(labelResponse.Result))
 	for _, label := range labelResponse.Result {
 		labelStrings = append(labelStrings, label.LabelName)
 	}
-	return labelStrings, nil
+	return labelStrings, annos, nil
 }
 
-func (c *Client) GetServiceCatalogRequestedItemStates(ctx context.Context) ([]RequestItemState, error) {
+func (c *Client) GetServiceCatalogRequestedItemStates(ctx context.Context) ([]RequestItemState, annotations.Annotations, error) {
 	var catalogsResponse RequestedItemStateResponse
-	_, _, err := c.get(
+	_, annos, err := c.get(
 		ctx,
 		c.apiURL(ChoiceBaseUrl, c.deployment),
 		&catalogsResponse,
@@ -283,15 +294,15 @@ func (c *Client) GetServiceCatalogRequestedItemStates(ctx context.Context) ([]Re
 		WithFields("label,value"),
 	)
 	if err != nil {
-		return nil, err
+		return nil, annos, err
 	}
-	return catalogsResponse.Result, nil
+	return catalogsResponse.Result, annos, nil
 }
 
 // Unused.
-func (c *Client) GetCatalogs(ctx context.Context, paginationVars PaginationVars) ([]Catalog, string, error) {
+func (c *Client) GetCatalogs(ctx context.Context, paginationVars PaginationVars) ([]Catalog, string, annotations.Annotations, error) {
 	var catalogsResponse CatalogsResponse
-	nextPageToken, _, err := c.get(
+	nextPageToken, annos, err := c.get(
 		ctx,
 		c.apiURL(ServiceCatalogListCatalogsUrl, c.deployment),
 		&catalogsResponse,
@@ -299,7 +310,7 @@ func (c *Client) GetCatalogs(ctx context.Context, paginationVars PaginationVars)
 		WithOffset(paginationVars.Offset),
 	)
 	if err != nil {
-		return nil, "", err
+		return nil, "", annos, err
 	}
-	return catalogsResponse.Result, nextPageToken, nil
+	return catalogsResponse.Result, nextPageToken, annos, nil
 }

--- a/pkg/servicenow/service_catalog_request.go
+++ b/pkg/servicenow/service_catalog_request.go
@@ -21,7 +21,7 @@ func WithCustomField(id string, value interface{}) FieldOption {
 
 func (c *Client) GetServiceCatalogRequest(ctx context.Context, requestId string) (*ServiceCatalogRequest, error) {
 	var serviceCatalogRequestResponse ServiceCatalogRequestResponse
-	_, err := c.get(
+	_, _, err := c.get(
 		ctx,
 		c.apiURL(ServiceCatalogRequestDetailsBaseUrl, c.deployment, requestId),
 		&serviceCatalogRequestResponse,
@@ -35,7 +35,7 @@ func (c *Client) GetServiceCatalogRequest(ctx context.Context, requestId string)
 
 func (c *Client) GetServiceCatalogRequestItem(ctx context.Context, requestItemId string) (*RequestedItem, error) {
 	var requestItemResponse RequestItemResponse
-	_, err := c.get(
+	_, _, err := c.get(
 		ctx,
 		c.apiURL(ServiceCatalogRequestedItemDetailsBaseUrl, c.deployment, requestItemId),
 		&requestItemResponse,
@@ -80,7 +80,7 @@ func (c *Client) UpdateServiceCatalogRequestItem(ctx context.Context, requestIte
 
 func (c *Client) GetServiceCatalogRequestItems(ctx context.Context, reqOptions ...ReqOpt) ([]RequestedItem, string, error) {
 	var requestItemsResponse RequestItemsResponse
-	nextPageToken, err := c.get(
+	nextPageToken, _, err := c.get(
 		ctx,
 		c.apiURL(ServiceCatalogRequestedItemBaseUrl, c.deployment),
 		&requestItemsResponse,
@@ -101,7 +101,7 @@ func (c *Client) GetCatalogItems(ctx context.Context, paginationVars *Pagination
 	for k, v := range c.TicketSchemaFilters {
 		reqOpts = append(reqOpts, WithQueryParam(k, v))
 	}
-	nextPageToken, err := c.get(
+	nextPageToken, _, err := c.get(
 		ctx,
 		c.apiURL(ServiceCatalogItemBaseUrl, c.deployment),
 		&catalogItemsResponse,
@@ -115,7 +115,7 @@ func (c *Client) GetCatalogItems(ctx context.Context, paginationVars *Pagination
 
 func (c *Client) GetCatalogItem(ctx context.Context, catalogItemId string) (*CatalogItem, error) {
 	var catalogItemResponse CatalogItemResponse
-	_, err := c.get(
+	_, _, err := c.get(
 		ctx,
 		c.apiURL(ServiceCatalogItemGetUrl, c.deployment, catalogItemId),
 		&catalogItemResponse,
@@ -128,7 +128,7 @@ func (c *Client) GetCatalogItem(ctx context.Context, catalogItemId string) (*Cat
 
 func (c *Client) GetCatalogItemVariables(ctx context.Context, catalogItemId string) ([]CatalogItemVariable, error) {
 	var catalogItemVariablesResponse CatalogItemVariablesResponse
-	_, err := c.get(
+	_, _, err := c.get(
 		ctx,
 		c.apiURL(ServiceCatalogItemVariablesUrl, c.deployment, catalogItemId),
 		&catalogItemVariablesResponse,
@@ -221,7 +221,7 @@ func (c *Client) CreateLabel(ctx context.Context, label string) (*Label, error) 
 
 func (c *Client) GetLabel(ctx context.Context, label string) (*Label, error) {
 	var labelsResponse LabelsResponse
-	_, err := c.get(
+	_, _, err := c.get(
 		ctx,
 		c.apiURL(LabelBaseUrl, c.deployment),
 		&labelsResponse,
@@ -256,7 +256,7 @@ func (c *Client) createLabel(ctx context.Context, label string) (*Label, error) 
 
 func (c *Client) GetLabelsForRequestedItem(ctx context.Context, requestedItemId string) ([]string, error) {
 	var labelResponse LabelEntriesLabelNameResponse
-	_, err := c.get(
+	_, _, err := c.get(
 		ctx,
 		c.apiURL(LabelEntryBaseUrl, c.deployment),
 		&labelResponse,
@@ -275,7 +275,7 @@ func (c *Client) GetLabelsForRequestedItem(ctx context.Context, requestedItemId 
 
 func (c *Client) GetServiceCatalogRequestedItemStates(ctx context.Context) ([]RequestItemState, error) {
 	var catalogsResponse RequestedItemStateResponse
-	_, err := c.get(
+	_, _, err := c.get(
 		ctx,
 		c.apiURL(ChoiceBaseUrl, c.deployment),
 		&catalogsResponse,
@@ -291,7 +291,7 @@ func (c *Client) GetServiceCatalogRequestedItemStates(ctx context.Context) ([]Re
 // Unused.
 func (c *Client) GetCatalogs(ctx context.Context, paginationVars PaginationVars) ([]Catalog, string, error) {
 	var catalogsResponse CatalogsResponse
-	nextPageToken, err := c.get(
+	nextPageToken, _, err := c.get(
 		ctx,
 		c.apiURL(ServiceCatalogListCatalogsUrl, c.deployment),
 		&catalogsResponse,


### PR DESCRIPTION
The client discarded every rate-limit signal ServiceNow sent.

- **On failure**, errors were built with a bare `status.Errorf`, so the SDK retryer never saw a `RateLimitDescription` and fell back to blind linear backoff — 1s, 2s, 3s … — bursting requests at an instance that had just asked us to back off.
- **On success**, rate-limit headers were dropped entirely. The SDK had nothing to pace with, so it could only ever react to a 429 rather than avoid one.

## What this does

Adopts `uhttp.BaseHttpClient` so `uhttp.WithRatelimitData` is available, captures rate-limit data on **every** response, and returns it as annotations from the six keyset List methods through to the connector's `List` / `Grants` / `Validate`.

The value does not depend on ServiceNow actually emitting rate-limit headers — which is unconfirmed. `ExtractRateLimitData` synthesizes `STATUS_OVERLIMIT` plus a 60s reset for any bare 429, and that is what lets the retryer skip its ramp. There's a test pinning it.

## Also here, from the same code path

- **Deleted `handleStatusCode`.** It duplicated `uhttp.GrpcCodeFromHTTPStatus`, which is identical for 408/429/5xx/401/403/404/409/501 and the 5xx catch-all. Only 400 and other 4xx change (`Unknown` → `InvalidArgument`); both are non-retryable, so retry behaviour is unchanged.
- **`Cache-Control: no-cache`.** `BaseHttpClient` caches GET 200s in memory for an hour by default. A cached page would resurface grants that have since been revoked, so this opts out rather than inherit the default. Pinned by a test so it can't be silently re-enabled.
- **Dropped the `baton-servicenow:` prefix** from client errors — the connector layer already adds it, so a 429 was reported double-prefixed.
- **Base URL validated in `NewClient`.** `url.Parse` alone accepts nearly anything, so the override is also checked for scheme and host, and the deployment-derived value is checked as a bare host.

## Tests

Success path, error path with and without headers, cache opt-out, base-URL validation, and **401 retry recovery** — that last path had no coverage and this change rewires the error its `status.Code` check depends on.

## Scope

Refs CXP-830, **does not close it.** The unbounded retry itself is SDK-side: `parallel_syncer.go` passes `MaxAttempts: 0`, the only unbounded retryer in the SDK. This PR touches neither that nor the `DeadlineExceeded` timeout path that CXP-723 hit.

Known deviations left alone deliberately: the ticketing/catalog List methods still return no annotations, and List methods return value slices rather than pointer slices. Note the annotation plumbing is single-call-only by design — `Annotations.Merge` appends rather than replaces, and `Pick` returns the first match, so a future multi-call site needs to carry `*v2.RateLimitDescription` and call `WithRateLimiting` once instead of merging bags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)