### PR TITLE
[CXP-829] fix: keyset pagination stopped at the first ACL-hidden window

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -50,17 +50,14 @@ func groupResource(group *servicenow.Group) (*v2.Resource, error) {
 }
 
 func (g *groupResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
-	bag, lastID, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeGroup.Id})
+	bag, page, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeGroup.Id})
 	if err != nil {
 		return nil, "", nil, err
 	}
 
 	groups, nextPageToken, annos, err := g.client.GetGroups(
 		ctx,
-		servicenow.KeysetPaginationVars{
-			Limit:  ResourcesPageSize,
-			LastID: lastID,
-		},
+		page,
 		nil,
 	)
 	if err != nil {
@@ -106,7 +103,7 @@ func (g *groupResourceType) Entitlements(ctx context.Context, resource *v2.Resou
 }
 
 func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, pt *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	bag, lastID, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeGroup.Id})
+	bag, page, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeGroup.Id})
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -115,10 +112,7 @@ func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, p
 		ctx,
 		"", // all users, domain-filtered when allowed-domains is set
 		resource.Id.Resource,
-		servicenow.KeysetPaginationVars{
-			Limit:  ResourcesPageSize,
-			LastID: lastID,
-		},
+		page,
 	)
 	if err != nil {
 		return nil, "", annos, fmt.Errorf("baton-servicenow: failed to list groupMembers: %w", err)

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -2,8 +2,6 @@ package connector
 
 import (
 	"fmt"
-	"regexp"
-	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -23,25 +21,20 @@ import (
 const ResourcesPageSize = 200
 const TicketSchemasPageSize = 25
 
-// sysIDPattern matches a ServiceNow sys_id: 32 hex characters. ServiceNow's
-// storage collation is case-insensitive, so either case is accepted and
-// normalized to lowercase for a stable cursor.
-var sysIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{32}$`)
-
 func annotationsForUserResourceType() annotations.Annotations {
 	annos := annotations.Annotations{}
 	annos.Update(&v2.SkipEntitlementsAndGrants{})
 	return annos
 }
 
-// parsePageToken returns the bag along with its current page token, which for
-// keyset-paginated resources (users, roles, groups, membership) is the last
-// seen sys_id rather than a numeric offset.
-func parsePageToken(i string, resourceID *v2.ResourceId) (*pagination.Bag, string, error) {
+// parsePageToken returns the bag plus the seek position, decoded by the same codec
+// that produced it (servicenow.ParseKeysetToken) and carrying ResourcesPageSize as
+// the limit. A malformed token fails loudly rather than restarting: a wrong guess
+// means silently wrong pagination.
+func parsePageToken(i string, resourceID *v2.ResourceId) (*pagination.Bag, servicenow.KeysetPaginationVars, error) {
 	b := &pagination.Bag{}
-	err := b.Unmarshal(i)
-	if err != nil {
-		return nil, "", err
+	if err := b.Unmarshal(i); err != nil {
+		return nil, servicenow.KeysetPaginationVars{}, err
 	}
 
 	if b.Current() == nil {
@@ -51,19 +44,16 @@ func parsePageToken(i string, resourceID *v2.ResourceId) (*pagination.Bag, strin
 		})
 	}
 
-	token := b.PageToken()
-	if token == "" {
-		return b, "", nil
+	lastID, offset, err := servicenow.ParseKeysetToken(b.PageToken())
+	if err != nil {
+		return nil, servicenow.KeysetPaginationVars{}, fmt.Errorf("baton-servicenow: %w", err)
 	}
 
-	// A valid sys_id cursor normalizes to lowercase; anything else --
-	// including a pre-keyset numeric offset token -- fails loudly rather
-	// than guessing, since a wrong guess here means silently wrong
-	// pagination results, not just a restart.
-	if !sysIDPattern.MatchString(token) {
-		return nil, "", fmt.Errorf("baton-servicenow: malformed page token %q", token)
-	}
-	return b, strings.ToLower(token), nil
+	return b, servicenow.KeysetPaginationVars{
+		Limit:  ResourcesPageSize,
+		LastID: lastID,
+		Offset: offset,
+	}, nil
 }
 
 // convertPageToken converts a string token into an int.

--- a/pkg/connector/helpers_test.go
+++ b/pkg/connector/helpers_test.go
@@ -5,6 +5,7 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
+	"github.com/conductorone/baton-servicenow/pkg/servicenow"
 )
 
 // marshalPageToken builds the serialized bag token an SDK-driven sync would
@@ -29,12 +30,8 @@ func marshalPageToken(t *testing.T, resourceID *v2.ResourceId, checkpointedToken
 	return marshaled
 }
 
-// TestParsePageToken_TokenValidation covers the two shapes a checkpointed
-// page token can take: (1) a real sys_id passes through as the seek
-// cursor, normalized to lowercase; (2) anything else -- including a
-// pre-keyset numeric offset token -- fails loudly instead of guessing,
-// since a wrong guess here means silently wrong pagination results, not
-// just a restart.
+// The shapes a checkpointed page token can take. Anything else must fail loudly:
+// a wrong guess means silently wrong pagination, not just a restart.
 func TestParsePageToken_TokenValidation(t *testing.T) {
 	resourceID := &v2.ResourceId{ResourceType: "role"}
 
@@ -60,12 +57,12 @@ func TestParsePageToken_TokenValidation(t *testing.T) {
 		sysID := "cc6f85b5ebc31300a210a2505206fec0"
 		keysetToken := marshalPageToken(t, resourceID, sysID)
 
-		_, lastID, err := parsePageToken(keysetToken, resourceID)
+		_, page, err := parsePageToken(keysetToken, resourceID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if lastID != sysID {
-			t.Errorf("lastID = %q, want %q", lastID, sysID)
+		if page.LastID != sysID {
+			t.Errorf("lastID = %q, want %q", page.LastID, sysID)
 		}
 	})
 
@@ -73,23 +70,77 @@ func TestParsePageToken_TokenValidation(t *testing.T) {
 		sysID := "CC6F85B5EBC31300A210A2505206FEC0"
 		keysetToken := marshalPageToken(t, resourceID, sysID)
 
-		_, lastID, err := parsePageToken(keysetToken, resourceID)
+		_, page, err := parsePageToken(keysetToken, resourceID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		want := "cc6f85b5ebc31300a210a2505206fec0"
-		if lastID != want {
-			t.Errorf("lastID = %q, want %q (ServiceNow's collation is case-insensitive; normalize for a stable cursor)", lastID, want)
+		if page.LastID != want {
+			t.Errorf("lastID = %q, want %q (ServiceNow's collation is case-insensitive; normalize for a stable cursor)", page.LastID, want)
 		}
 	})
 
 	t.Run("empty token (first page) passes through unchanged", func(t *testing.T) {
-		_, lastID, err := parsePageToken("", resourceID)
+		_, page, err := parsePageToken("", resourceID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if lastID != "" {
-			t.Errorf("lastID = %q, want empty", lastID)
+		if page.LastID != "" {
+			t.Errorf("lastID = %q, want empty", page.LastID)
+		}
+	})
+
+	t.Run("cursor with skip offset yields both halves", func(t *testing.T) {
+		sysID := "cc6f85b5ebc31300a210a2505206fec0"
+		// Built by the client layer's encoder, so a format change can't pass here.
+		keysetToken := marshalPageToken(t, resourceID, servicenow.EncodeKeysetToken(sysID, 400))
+
+		_, page, err := parsePageToken(keysetToken, resourceID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if page.LastID != sysID {
+			t.Errorf("lastID = %q, want %q", page.LastID, sysID)
+		}
+		if page.Offset != 400 {
+			t.Errorf("offset = %d, want 400", page.Offset)
+		}
+	})
+
+	t.Run("skip offset with no cursor is accepted", func(t *testing.T) {
+		// The first window of a listing can be the emptied one: offset, no cursor.
+		keysetToken := marshalPageToken(t, resourceID, servicenow.EncodeKeysetToken("", 200))
+
+		_, page, err := parsePageToken(keysetToken, resourceID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if page.LastID != "" {
+			t.Errorf("lastID = %q, want empty", page.LastID)
+		}
+		if page.Offset != 200 {
+			t.Errorf("offset = %d, want 200", page.Offset)
+		}
+	})
+
+	t.Run("cursor with non-numeric offset fails loudly", func(t *testing.T) {
+		keysetToken := marshalPageToken(t, resourceID, "cc6f85b5ebc31300a210a2505206fec0:abc")
+
+		_, _, err := parsePageToken(keysetToken, resourceID)
+		if err == nil {
+			t.Fatalf("expected an error for a non-numeric offset, got nil")
+		}
+	})
+
+	t.Run("plain cursor reports offset zero", func(t *testing.T) {
+		keysetToken := marshalPageToken(t, resourceID, servicenow.EncodeKeysetToken("cc6f85b5ebc31300a210a2505206fec0", 0))
+
+		_, page, err := parsePageToken(keysetToken, resourceID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if page.Offset != 0 {
+			t.Errorf("offset = %d, want 0 (a plain cursor is the fast path)", page.Offset)
 		}
 	})
 }

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -49,17 +49,14 @@ func roleResource(role *servicenow.Role) (*v2.Resource, error) {
 }
 
 func (r *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
-	bag, lastID, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeRole.Id})
+	bag, page, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeRole.Id})
 	if err != nil {
 		return nil, "", nil, err
 	}
 
 	roles, nextPageToken, annos, err := r.client.GetRoles(
 		ctx,
-		servicenow.KeysetPaginationVars{
-			Limit:  ResourcesPageSize,
-			LastID: lastID,
-		},
+		page,
 	)
 	if err != nil {
 		return nil, "", annos, fmt.Errorf("baton-servicenow: failed to list roles: %w", err)
@@ -104,7 +101,7 @@ func (r *roleResourceType) Entitlements(ctx context.Context, resource *v2.Resour
 }
 
 func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	bag, lastID, err := parsePageToken(pt.Token, resource.Id)
+	bag, page, err := parsePageToken(pt.Token, resource.Id)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -129,10 +126,7 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 			ctx,
 			"", // all users, domain-filtered when allowed-domains is set
 			resource.Id.Resource,
-			servicenow.KeysetPaginationVars{
-				Limit:  ResourcesPageSize,
-				LastID: lastID,
-			},
+			page,
 		)
 		annos = userAnnos
 		if err != nil {
@@ -164,10 +158,7 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 			ctx,
 			"", // all groups
 			resource.Id.Resource,
-			servicenow.KeysetPaginationVars{
-				Limit:  ResourcesPageSize,
-				LastID: lastID,
-			},
+			page,
 		)
 		annos = groupAnnos
 		if err != nil {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -69,17 +69,14 @@ func userResource(user *servicenow.User) (*v2.Resource, error) {
 }
 
 func (u *userResourceType) List(ctx context.Context, _ *v2.ResourceId, pt *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
-	bag, lastID, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeUser.Id})
+	bag, page, err := parsePageToken(pt.Token, &v2.ResourceId{ResourceType: resourceTypeUser.Id})
 	if err != nil {
 		return nil, "", nil, err
 	}
 
 	users, nextPageToken, annos, err := u.client.GetUsers(
 		ctx,
-		servicenow.KeysetPaginationVars{
-			Limit:  ResourcesPageSize,
-			LastID: lastID,
-		},
+		page,
 	)
 	if err != nil {
 		return nil, "", annos, fmt.Errorf("baton-servicenow: failed to list users: %w", err)

--- a/pkg/servicenow/client.go
+++ b/pkg/servicenow/client.go
@@ -189,14 +189,87 @@ func (c *Client) apiURL(pattern string, args ...any) string {
 // getKeysetPage runs one keyset-paginated Table API GET and derives the
 // next seek token from the response. Uses c.getKeyset, not c.get: keyset
 // callers compute their own token via nextKeysetToken and don't need
-// doRequest's legacy Link-header token.
-func getKeysetPage[T any](ctx context.Context, c *Client, url string, reqOpts []ReqOpt, idFn func(T) string) ([]T, string, annotations.Annotations, error) {
+// doRequest's legacy Link-header token. An empty result is not the end of
+// the listing -- see nextSkipToken.
+func getKeysetPage[T any](
+	ctx context.Context,
+	c *Client,
+	url string,
+	filterVars *FilterVars,
+	keysetVars *KeysetPaginationVars,
+	idFn func(T) string,
+) ([]T, string, annotations.Annotations, error) {
+	if keysetVars.Limit <= 0 {
+		return nil, "", nil, fmt.Errorf("keyset pagination called with Limit %d for %s", keysetVars.Limit, url)
+	}
+
 	var resp ListResponse[T]
-	annos, err := c.getKeyset(ctx, url, &resp, reqOpts...)
+	header, annos, err := c.getKeyset(ctx, url, &resp, buildKeysetReqOptions(filterVars, keysetVars)...)
 	if err != nil {
 		return nil, "", annos, err
 	}
+
+	if len(resp.Result) == 0 {
+		return nil, nextSkipToken(ctx, url, header, keysetVars), annos, nil
+	}
+
+	if keysetVars.Offset > 0 {
+		ctxzap.Extract(ctx).Debug("baton-servicenow: stepped past rows the sync account cannot read",
+			zap.String("url", url),
+			zap.String("cursor", keysetVars.LastID),
+			zap.Int("offset", keysetVars.Offset),
+		)
+	}
 	return resp.Result, nextKeysetToken(resp.Result, idFn), annos, nil
+}
+
+// nextSkipToken decides what an empty page means: the end of the listing (""),
+// or a window row-level ACLs emptied (a token stepping the offset past it).
+// X-Total-Count counts matching rows before ACLs run, so it still sees the rows
+// this page could not.
+func nextSkipToken(ctx context.Context, url string, header http.Header, v *KeysetPaginationVars) string {
+	l := ctxzap.Extract(ctx)
+
+	// Existence checks pass Limit 1: empty is the answer, not a page boundary.
+	if v.Limit <= 1 {
+		return ""
+	}
+
+	count, ok := readTotalCount(header)
+	if !ok {
+		l.Debug("baton-servicenow: ending the listing, row count unavailable",
+			zap.String("url", url),
+			zap.String("cursor", v.LastID),
+		)
+		return ""
+	}
+
+	// The window covered rows Offset+1..Offset+Limit past the cursor. Anything
+	// beyond that is a row this page never reached, so the emptiness was the ACL.
+	next := v.Offset + v.Limit
+	if count <= next {
+		l.Debug("baton-servicenow: ending the listing, no rows past the window",
+			zap.String("url", url),
+			zap.String("cursor", v.LastID),
+			zap.Int("count", count),
+			zap.Int("offset", v.Offset),
+		)
+		return ""
+	}
+	return EncodeKeysetToken(v.LastID, next)
+}
+
+// readTotalCount parses the row count ServiceNow puts in X-Total-Count.
+func readTotalCount(header http.Header) (int, bool) {
+	raw := header.Get("X-Total-Count")
+	if raw == "" {
+		return 0, false
+	}
+	size, err := ConvertPageToken(raw)
+	if err != nil {
+		return 0, false
+	}
+	return size, true
 }
 
 // Table sys_user (Users). GetUsers always enumerates -- there's no
@@ -205,9 +278,9 @@ func getKeysetPage[T any](ctx context.Context, c *Client, url string, reqOpts []
 // configured.
 func (c *Client) GetUsers(ctx context.Context, paginationVars KeysetPaginationVars) ([]User, string, annotations.Annotations, error) {
 	paginationVars = cappedForDomainFilter("", c.AllowedDomains, paginationVars)
-	reqOpts := buildKeysetReqOptions(prepareUserFilters(c.AllowedDomains, c.CustomUserFields), &paginationVars)
-
-	return getKeysetPage(ctx, c, c.apiURL(UsersBaseUrl, c.deployment), reqOpts, func(u User) string { return u.Id })
+	return getKeysetPage(ctx, c, c.apiURL(UsersBaseUrl, c.deployment),
+		prepareUserFilters(c.AllowedDomains, c.CustomUserFields), &paginationVars,
+		func(u User) string { return u.Id })
 }
 
 func (c *Client) GetUser(ctx context.Context, userId string) (*User, annotations.Annotations, error) {
@@ -229,9 +302,9 @@ func (c *Client) GetUser(ctx context.Context, userId string) (*User, annotations
 
 // Table sys_user_group (Groups).
 func (c *Client) GetGroups(ctx context.Context, paginationVars KeysetPaginationVars, groupIDs []string) ([]Group, string, annotations.Annotations, error) {
-	reqOpts := buildKeysetReqOptions(prepareGroupFilters(groupIDs), &paginationVars)
-
-	return getKeysetPage(ctx, c, c.apiURL(GroupsBaseUrl, c.deployment), reqOpts, func(g Group) string { return g.Id })
+	return getKeysetPage(ctx, c, c.apiURL(GroupsBaseUrl, c.deployment),
+		prepareGroupFilters(groupIDs), &paginationVars,
+		func(g Group) string { return g.Id })
 }
 
 func (c *Client) GetGroup(ctx context.Context, groupId string) (*Group, annotations.Annotations, error) {
@@ -256,9 +329,9 @@ func (c *Client) GetGroup(ctx context.Context, groupId string) (*Group, annotati
 // the page size is capped (see domainFilteredPageSize).
 func (c *Client) GetUserToGroup(ctx context.Context, userId string, groupId string, paginationVars KeysetPaginationVars) ([]GroupMember, string, annotations.Annotations, error) {
 	paginationVars = cappedForDomainFilter(userId, c.AllowedDomains, paginationVars)
-	reqOpts := buildKeysetReqOptions(prepareUserToGroupFilter(userId, groupId, c.AllowedDomains), &paginationVars)
-
-	return getKeysetPage(ctx, c, c.apiURL(GroupMembersBaseUrl, c.deployment), reqOpts, func(m GroupMember) string { return m.Id })
+	return getKeysetPage(ctx, c, c.apiURL(GroupMembersBaseUrl, c.deployment),
+		prepareUserToGroupFilter(userId, groupId, c.AllowedDomains), &paginationVars,
+		func(m GroupMember) string { return m.Id })
 }
 
 func (c *Client) AddUserToGroup(ctx context.Context, record GroupMemberPayload) (annotations.Annotations, error) {
@@ -281,9 +354,9 @@ func (c *Client) RemoveUserFromGroup(ctx context.Context, id string) (annotation
 
 // Table sys_user_role (Roles).
 func (c *Client) GetRoles(ctx context.Context, paginationVars KeysetPaginationVars) ([]Role, string, annotations.Annotations, error) {
-	reqOpts := buildKeysetReqOptions(prepareRoleFilters(), &paginationVars)
-
-	return getKeysetPage(ctx, c, c.apiURL(RolesBaseUrl, c.deployment), reqOpts, func(r Role) string { return r.Id })
+	return getKeysetPage(ctx, c, c.apiURL(RolesBaseUrl, c.deployment),
+		prepareRoleFilters(), &paginationVars,
+		func(r Role) string { return r.Id })
 }
 
 // Table sys_user_has_role (User to Role). When userId is empty
@@ -291,9 +364,9 @@ func (c *Client) GetRoles(ctx context.Context, paginationVars KeysetPaginationVa
 // the page size is capped (see domainFilteredPageSize).
 func (c *Client) GetUserToRole(ctx context.Context, userId string, roleId string, paginationVars KeysetPaginationVars) ([]UserToRole, string, annotations.Annotations, error) {
 	paginationVars = cappedForDomainFilter(userId, c.AllowedDomains, paginationVars)
-	reqOpts := buildKeysetReqOptions(prepareUserToRoleFilter(userId, roleId, c.AllowedDomains), &paginationVars)
-
-	return getKeysetPage(ctx, c, c.apiURL(UserRolesBaseUrl, c.deployment), reqOpts, func(r UserToRole) string { return r.Id })
+	return getKeysetPage(ctx, c, c.apiURL(UserRolesBaseUrl, c.deployment),
+		prepareUserToRoleFilter(userId, roleId, c.AllowedDomains), &paginationVars,
+		func(r UserToRole) string { return r.Id })
 }
 
 func (c *Client) GrantRoleToUser(ctx context.Context, record UserToRolePayload) (annotations.Annotations, error) {
@@ -317,9 +390,9 @@ func (c *Client) RevokeRoleFromUser(ctx context.Context, id string) (annotations
 // Table sys_group_has_role (Group to Role). No domain filter -- groups
 // don't have an email to scope by.
 func (c *Client) GetGroupToRole(ctx context.Context, groupId string, roleId string, paginationVars KeysetPaginationVars) ([]GroupToRole, string, annotations.Annotations, error) {
-	reqOpts := buildKeysetReqOptions(prepareGroupToRoleFilter(groupId, roleId), &paginationVars)
-
-	return getKeysetPage(ctx, c, c.apiURL(GroupRolesBaseUrl, c.deployment), reqOpts, func(r GroupToRole) string { return r.Id })
+	return getKeysetPage(ctx, c, c.apiURL(GroupRolesBaseUrl, c.deployment),
+		prepareGroupToRoleFilter(groupId, roleId), &paginationVars,
+		func(r GroupToRole) string { return r.Id })
 }
 
 func (c *Client) GrantRoleToGroup(ctx context.Context, record GroupToRolePayload) (annotations.Annotations, error) {
@@ -353,7 +426,8 @@ func (c *Client) get(ctx context.Context, urlAddress string, resourceResponse in
 
 // getKeyset is like get but for keyset-paginated callers: it never computes
 // the legacy Link-header/X-Total-Count token, so it can't fail because of it.
-func (c *Client) getKeyset(ctx context.Context, urlAddress string, resourceResponse interface{}, reqOptions ...ReqOpt) (annotations.Annotations, error) {
+// Returns the headers as well, for X-Total-Count.
+func (c *Client) getKeyset(ctx context.Context, urlAddress string, resourceResponse interface{}, reqOptions ...ReqOpt) (http.Header, annotations.Annotations, error) {
 	return c.doRequestWithRetryKeyset(
 		ctx,
 		urlAddress,
@@ -423,7 +497,7 @@ func (c *Client) delete(
 // doRequest performs the request, decodes a successful JSON body into
 // resourceResponse, and returns the legacy Link-header/X-Total-Count
 // offset-pagination token used by Service Catalog/ticketing callers. Keyset
-// callers use doRequestKeyset instead.
+// callers use doRequestWithRetryKeyset instead.
 func (c *Client) doRequest(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (string, annotations.Annotations, error) {
 	header, annos, err := c.doHTTPRequest(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
 	if err != nil {
@@ -431,15 +505,6 @@ func (c *Client) doRequest(ctx context.Context, urlAddress string, method string
 	}
 	token, err := legacyOffsetToken(header)
 	return token, annos, err
-}
-
-// doRequestKeyset is doRequest without the legacy Link-header/X-Total-Count
-// token computation. Keyset callers derive their own token from the decoded
-// body (nextKeysetToken), so a malformed Link header or non-numeric
-// sysparm_offset must not discard an otherwise successfully decoded page.
-func (c *Client) doRequestKeyset(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (annotations.Annotations, error) {
-	_, annos, err := c.doHTTPRequest(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
-	return annos, err
 }
 
 // doHTTPRequest sends the request through uhttp and, for non-DELETE methods,
@@ -599,15 +664,17 @@ func (c *Client) doRequestWithRetry(ctx context.Context, urlAddress string, meth
 	})
 }
 
-// doRequestWithRetryKeyset is doRequestWithRetry for keyset callers, routed
-// through doRequestKeyset instead of doRequest so a legacy-pagination-header
-// hiccup can't fail an otherwise successfully decoded page.
-func (c *Client) doRequestWithRetryKeyset(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (annotations.Annotations, error) {
+// doRequestWithRetryKeyset is doRequestWithRetry for keyset callers. It skips
+// doRequest's legacy Link-header token, which could otherwise fail a page that
+// decoded fine, and hands back the headers for X-Total-Count.
+func (c *Client) doRequestWithRetryKeyset(ctx context.Context, urlAddress string, method string, data any, resourceResponse any, reqOptions ...ReqOpt) (http.Header, annotations.Annotations, error) {
+	var header http.Header
 	_, annos, err := withAuthRetry(ctx, urlAddress, method, func() (string, annotations.Annotations, error) {
-		a, err := c.doRequestKeyset(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
-		return "", a, err
+		h, a, reqErr := c.doHTTPRequest(ctx, urlAddress, method, data, resourceResponse, reqOptions...)
+		header = h
+		return "", a, reqErr
 	})
-	return annos, err
+	return header, annos, err
 }
 
 // withAuthRetry retries attempt on transient 401 responses, logging the

--- a/pkg/servicenow/client_test.go
+++ b/pkg/servicenow/client_test.go
@@ -95,14 +95,13 @@ func TestGetRoles_DoesNotTruncateOnShortNonEmptyPage(t *testing.T) {
 	}
 }
 
-// TestGetRoles_IgnoresMalformedLegacyPaginationHeaders guards against a
-// keyset page failing over the unrelated legacy Link-header/X-Total-Count
-// computation, which keyset callers never read (see doRequestKeyset in
-// client.go).
+// A keyset page must not fail over the legacy offset token, which keyset callers
+// never compute (see doRequestWithRetryKeyset). They do read X-Total-Count, but
+// only on an empty page, and an unparseable value there just ends the listing.
 func TestGetRoles_IgnoresMalformedLegacyPaginationHeaders(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// doRequest's legacy pagination-token logic would fail parsing this
-		// as an int; doRequestKeyset must never even attempt to.
+		// legacyOffsetToken would fail parsing this as an int; the keyset
+		// path must never even attempt to.
 		w.Header().Set("X-Total-Count", "not-a-number")
 		w.Header().Set("Content-Type", "application/json")
 
@@ -142,7 +141,7 @@ func TestGetUsers_CapsPageSizeWhenDomainFilterApplies(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewClient(uhttp.NewBaseHttpClient(server.Client()), "Basic dGVzdDp0ZXN0", "dev0", nil, []string{"draftkings.com"}, nil, server.URL)
+	client, err := NewClient(uhttp.NewBaseHttpClient(server.Client()), "Basic dGVzdDp0ZXN0", "dev0", nil, []string{"example.com"}, nil, server.URL)
 	if err != nil {
 		t.Fatalf("unexpected error creating client: %v", err)
 	}

--- a/pkg/servicenow/keyset_test.go
+++ b/pkg/servicenow/keyset_test.go
@@ -1,0 +1,522 @@
+package servicenow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
+)
+
+// aclStub emulates the Table API: sysparm_limit and sysparm_offset pick a window
+// before row-level ACLs run, and X-Total-Count counts matching rows without them.
+type aclStub[T any] struct {
+	ids            []string        // every row in the table, ascending
+	hidden         map[string]bool // rows the sync account may not read
+	newRow         func(id string) T
+	omitTotalCount bool // an instance that never sends the header
+	// Models an instance whose X-Total-Count is computed after ACL filtering.
+	reportPostACLCount bool
+	requests           int
+	seen               []stubRequest
+}
+
+type stubRequest struct {
+	query  string
+	limit  string
+	offset string
+}
+
+func (s *aclStub[T]) handler(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		s.requests++
+		s.seen = append(s.seen, stubRequest{
+			query:  q.Get("sysparm_query"),
+			limit:  q.Get("sysparm_limit"),
+			offset: q.Get("sysparm_offset"),
+		})
+
+		cursor := ""
+		if raw := q.Get("sysparm_query"); strings.Contains(raw, "sys_id>") {
+			rest := raw[strings.Index(raw, "sys_id>")+len("sys_id>"):]
+			cursor = strings.SplitN(rest, "^", 2)[0]
+		}
+
+		past := make([]string, 0, len(s.ids))
+		for _, id := range s.ids {
+			if id > cursor {
+				past = append(past, id)
+			}
+		}
+
+		limit, _ := strconv.Atoi(q.Get("sysparm_limit"))
+		offset, _ := strconv.Atoi(q.Get("sysparm_offset"))
+
+		// The window is cut before ACLs run.
+		window := past
+		if offset < len(window) {
+			window = window[offset:]
+		} else {
+			window = nil
+		}
+		if limit > 0 && limit < len(window) {
+			window = window[:limit]
+		}
+
+		rows := make([]T, 0, len(window))
+		for _, id := range window {
+			if !s.hidden[id] {
+				rows = append(rows, s.newRow(id))
+			}
+		}
+
+		if !s.omitTotalCount {
+			count := len(past) // the COUNT(*): matching rows, ACLs not applied
+			switch {
+			case s.reportPostACLCount:
+				count = len(rows)
+			case q.Get("sysparm_no_count") == "true":
+				// Modelled so reintroducing the parameter fails the ACL tests
+				// instead of silently reverting the fix: the window size cannot
+				// tell an emptied window from the end of the table.
+				count = len(window)
+			}
+			w.Header().Set("X-Total-Count", strconv.Itoa(count))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(ListResponse[T]{Result: rows}); err != nil {
+			t.Errorf("failed to encode test response: %v", err)
+		}
+	}
+}
+
+// sysID renders n as a 32-hex sys_id, zero-padded so string order matches n. Real
+// sys_ids are needed because the token codec validates their shape.
+func sysID(n int) string {
+	return fmt.Sprintf("%032x", n)
+}
+
+// sysIDs is sysID over a range, inclusive.
+func sysIDs(from, to int) []string {
+	ids := make([]string, 0, to-from+1)
+	for n := from; n <= to; n++ {
+		ids = append(ids, sysID(n))
+	}
+	return ids
+}
+
+// newACLStub builds a stub for any row type; T comes from newRow.
+func newACLStub[T any](newRow func(id string) T, ids []string, hidden ...string) *aclStub[T] {
+	h := make(map[string]bool, len(hidden))
+	for _, id := range hidden {
+		h[id] = true
+	}
+	return &aclStub[T]{ids: ids, hidden: h, newRow: newRow}
+}
+
+func roleStub(ids []string, hidden ...string) *aclStub[Role] {
+	return newACLStub(func(id string) Role { return Role{BaseResource: BaseResource{Id: id}} }, ids, hidden...)
+}
+
+func userToRoleStub(ids []string, hidden ...string) *aclStub[UserToRole] {
+	return newACLStub(func(id string) UserToRole { return UserToRole{BaseResource: BaseResource{Id: id}} }, ids, hidden...)
+}
+
+func newStubClient[T any](t *testing.T, stub *aclStub[T], domains []string) (*Client, func()) {
+	t.Helper()
+	server := httptest.NewServer(stub.handler(t))
+	client, err := NewClient(uhttp.NewBaseHttpClient(server.Client()), "Basic dGVzdDp0ZXN0", "dev0", nil, domains, nil, server.URL)
+	if err != nil {
+		server.Close()
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+	return client, server.Close
+}
+
+// drain walks a listing the way the SDK does, feeding each token back in. Guards
+// against a pagination bug that repeats a token or never terminates.
+func drain[T any](t *testing.T, bound int, step func(KeysetPaginationVars) ([]T, string, error)) []T {
+	t.Helper()
+
+	var got []T
+	token := ""
+	for range bound {
+		lastID, offset, err := ParseKeysetToken(token)
+		if err != nil {
+			t.Fatalf("connector returned an unparseable token %q: %v", token, err)
+		}
+
+		page, next, err := step(KeysetPaginationVars{LastID: lastID, Offset: offset})
+		if err != nil {
+			t.Fatalf("unexpected error on token %q: %v", token, err)
+		}
+		got = append(got, page...)
+		if next == "" {
+			return got
+		}
+		if next == token {
+			t.Fatalf("token %q repeated -- pagination would loop forever", next)
+		}
+		token = next
+	}
+	t.Fatalf("pagination did not terminate within %d pages", bound)
+	return nil
+}
+
+// drainRoles drains a role listing and returns the sys_ids collected.
+func drainRoles(t *testing.T, client *Client, limit int, bound int) []string {
+	t.Helper()
+
+	rows := drain(t, bound, func(page KeysetPaginationVars) ([]Role, string, error) {
+		page.Limit = limit
+		rows, next, _, err := client.GetRoles(context.Background(), page)
+		return rows, next, err
+	})
+
+	ids := make([]string, 0, len(rows))
+	for _, r := range rows {
+		ids = append(ids, r.Id)
+	}
+	return ids
+}
+
+// A whole window hidden by row-level read ACLs must not end the listing while
+// readable rows remain past it.
+func TestGetRoles_StepsPastACLEmptiedWindow(t *testing.T) {
+	// Limit 2, so the window 3..4 is emptied in full. Limit 1 would be a
+	// point lookup, which deliberately skips all of this.
+	stub := roleStub(sysIDs(1, 6), sysID(3), sysID(4))
+	client, done := newStubClient(t, stub, nil)
+	defer done()
+
+	got := drainRoles(t, client, 2, 20)
+
+	want := []string{sysID(1), sysID(2), sysID(5), sysID(6)}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("rows synced = %v, want %v (the listing must continue past a window emptied by row-level ACLs)", got, want)
+	}
+}
+
+// A run of unreadable rows longer than one window: the skip advances more than once.
+func TestGetRoles_StepsPastLongACLEmptiedRun(t *testing.T) {
+	stub := roleStub(sysIDs(1, 8), sysID(3), sysID(4), sysID(5), sysID(6))
+	client, done := newStubClient(t, stub, nil)
+	defer done()
+
+	got := drainRoles(t, client, 2, 20)
+
+	want := []string{sysID(1), sysID(2), sysID(7), sysID(8)}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("rows synced = %v, want %v", got, want)
+	}
+
+	// Every request is a page fetch: no request exists purely to ask for a count.
+	for i, req := range stub.seen {
+		if req.limit == "1" {
+			t.Errorf("request %d has limit 1: a separate count probe should not exist", i)
+		}
+	}
+}
+
+// The normal path: an empty page past the last row ends the listing.
+func TestGetRoles_TerminatesOnGenuineEnd(t *testing.T) {
+	stub := roleStub(sysIDs(1, 2))
+	client, done := newStubClient(t, stub, nil)
+	defer done()
+
+	got := drainRoles(t, client, 2, 10)
+
+	if strings.Join(got, ",") != strings.Join(sysIDs(1, 2), ",") {
+		t.Errorf("rows synced = %v, want the two readable rows", got)
+	}
+	if stub.requests != 2 {
+		t.Errorf("requests = %d, want 2 (one page, one terminator)", stub.requests)
+	}
+}
+
+// The tail case: every remaining row unreadable must end cleanly, not fail a sync
+// that already collected everything it is allowed to see.
+func TestGetRoles_TerminatesWhenEveryRemainingRowIsUnreadable(t *testing.T) {
+	stub := roleStub(sysIDs(1, 3), sysID(2), sysID(3))
+	client, done := newStubClient(t, stub, nil)
+	defer done()
+
+	got := drainRoles(t, client, 2, 10)
+
+	if strings.Join(got, ",") != sysID(1) {
+		t.Errorf("rows synced = %v, want only the first row (the rest are unreadable)", got)
+	}
+}
+
+// A deployment that never sends X-Total-Count ends the listing instead of stepping
+// blindly, which has no bound. It can under-report, but never fails a sync nor loops.
+func TestGetRoles_EndsListingWhenRowCountUnavailable(t *testing.T) {
+	stub := roleStub(sysIDs(1, 8), sysID(3), sysID(4))
+	stub.omitTotalCount = true
+	client, done := newStubClient(t, stub, nil)
+	defer done()
+
+	got := drainRoles(t, client, 2, 20)
+
+	if strings.Join(got, ",") != strings.Join(sysIDs(1, 2), ",") {
+		t.Errorf("rows synced = %v, want the rows before the hidden block", got)
+	}
+}
+
+// The skip is bounded by the row count, so a hidden tail cannot walk past the table.
+func TestGetRoles_StopsSteppingAtTheRowCount(t *testing.T) {
+	ids := sysIDs(1, 8)
+	stub := roleStub(ids, ids...) // every row unreadable
+	client, done := newStubClient(t, stub, nil)
+	defer done()
+
+	got := drainRoles(t, client, 2, 10)
+
+	if len(got) != 0 {
+		t.Errorf("rows synced = %v, want none (every row is unreadable)", got)
+	}
+	// 8 rows at limit 2: windows at offset 0,2,4,6 and then the count stops it.
+	if stub.requests > 5 {
+		t.Errorf("requests = %d, want at most 5: the row count must bound the walk", stub.requests)
+	}
+}
+
+// A seek page that returns rows costs one request and no follow-up.
+func TestGetRoles_ProductivePageCostsOneRequest(t *testing.T) {
+	stub := roleStub(sysIDs(1, 3))
+	client, done := newStubClient(t, stub, nil)
+	defer done()
+
+	if _, _, _, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 2, LastID: sysID(1)}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stub.requests != 1 {
+		t.Fatalf("requests = %d, want 1 (a page that returns rows needs no follow-up)", stub.requests)
+	}
+	if got := stub.seen[0].query; !strings.Contains(got, "sys_id>"+sysID(1)) {
+		t.Errorf("query = %q, want the seek condition", got)
+	}
+}
+
+// A listing with no rows costs one request: the count already says zero.
+func TestGetRoles_EmptyListingCostsOneRequest(t *testing.T) {
+	stub := roleStub(nil)
+	client, done := newStubClient(t, stub, nil)
+	defer done()
+
+	_, next, _, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 200})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if next != "" {
+		t.Errorf("next token = %q, want empty for an empty listing", next)
+	}
+	if stub.requests != 1 {
+		t.Errorf("requests = %d, want 1", stub.requests)
+	}
+}
+
+// Provisioning existence checks (Limit 1) must not step: empty is the answer.
+func TestGetUserToRole_PointLookupMakesOneRequest(t *testing.T) {
+	stub := userToRoleStub(nil)
+	client, done := newStubClient(t, stub, nil)
+	defer done()
+
+	rows, _, _, err := client.GetUserToRole(context.Background(), "user-1", "role-1", KeysetPaginationVars{Limit: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("rows = %v, want none", rows)
+	}
+	if stub.requests != 1 {
+		t.Fatalf("requests = %d, want 1 (an existence check must not step)", stub.requests)
+	}
+	if got := stub.seen[0].offset; got != "" && got != "0" {
+		t.Errorf("sysparm_offset = %q, want unset for a point lookup", got)
+	}
+}
+
+// A point lookup must never escalate: it has no page to continue.
+func TestGetUserToRole_PointLookupNeverEscalates(t *testing.T) {
+	stub := userToRoleStub(sysIDs(1, 4), sysID(1), sysID(2), sysID(3), sysID(4))
+	client, done := newStubClient(t, stub, nil)
+	defer done()
+
+	rows, next, _, err := client.GetUserToRole(context.Background(), "user-1", "role-1", KeysetPaginationVars{Limit: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("rows = %v, want none", rows)
+	}
+	if next != "" {
+		t.Errorf("next token = %q, want empty: an existence check has no page to continue", next)
+	}
+	if stub.requests != 1 {
+		t.Errorf("requests = %d, want 1", stub.requests)
+	}
+}
+
+// The allowed-domains filter must survive every request of a listing, skip included:
+// dropping it there would recover rows scoped differently from the page it replaces.
+func TestGetUserToRole_DomainFilterSurvivesTheSkip(t *testing.T) {
+	stub := userToRoleStub(sysIDs(1, 5), sysID(3), sysID(4))
+	client, done := newStubClient(t, stub, []string{"example.com"})
+	defer done()
+
+	rows := drain(t, 20, func(page KeysetPaginationVars) ([]UserToRole, string, error) {
+		page.Limit = 2
+		rows, next, _, err := client.GetUserToRole(context.Background(), "", "role-1", page)
+		return rows, next, err
+	})
+	got := make([]string, 0, len(rows))
+	for _, r := range rows {
+		got = append(got, r.Id)
+	}
+
+	if strings.Join(got, ",") != strings.Join([]string{sysID(1), sysID(2), sysID(5)}, ",") {
+		t.Errorf("rows synced = %v, want rows 1, 2 and 5", got)
+	}
+
+	sawSkipOffset := false
+	for i, req := range stub.seen {
+		if !strings.Contains(req.query, "user.emailENDSWITH@example.com") {
+			t.Errorf("request %d query = %q, want the allowed-domains filter on every request", i, req.query)
+		}
+		if !strings.Contains(req.query, "role=role-1") {
+			t.Errorf("request %d query = %q, want the role scope on every request", i, req.query)
+		}
+		if !strings.Contains(req.query, "ORDERBYsys_id") {
+			t.Errorf("request %d query = %q, want ORDERBYsys_id on every request", i, req.query)
+		}
+		if req.offset != "" && req.offset != "0" {
+			sawSkipOffset = true
+		}
+	}
+	if !sawSkipOffset {
+		t.Error("no request carried a skip offset -- the ACL-emptied window was not stepped past")
+	}
+}
+
+// The domain filter must survive a skip that overrides the capped page size.
+func TestGetUserToRole_DomainFilterCapsPageSizeOnSkip(t *testing.T) {
+	ids := sysIDs(1, 300)
+	stub := userToRoleStub(ids, ids...)
+	client, done := newStubClient(t, stub, []string{"example.com"})
+	defer done()
+
+	// Enumeration (empty userId) with allowed-domains set: the cap applies.
+	_, next, _, err := client.GetUserToRole(context.Background(), "", "role-1", KeysetPaginationVars{
+		Limit:  200,
+		LastID: sysID(1),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if next == "" {
+		t.Fatal("expected the listing to continue: rows remain past the cursor")
+	}
+
+	want := strconv.Itoa(domainFilteredPageSize)
+	for i, req := range stub.seen {
+		if req.limit != want {
+			t.Errorf("request %d sysparm_limit = %q, want the domain cap %q", i, req.limit, want)
+		}
+		if !strings.Contains(req.query, "user.emailENDSWITH@example.com") {
+			t.Errorf("request %d lost the allowed-domains filter: %q", i, req.query)
+		}
+	}
+}
+
+// One request per call is what makes every step of a skip survive a restart.
+func TestGetRoles_OneRequestPerCall(t *testing.T) {
+	stub := roleStub(sysIDs(1, 8), sysID(3), sysID(4), sysID(5), sysID(6))
+	client, done := newStubClient(t, stub, nil)
+	defer done()
+
+	calls := 0
+	drain(t, 20, func(page KeysetPaginationVars) ([]Role, string, error) {
+		page.Limit = 2
+		before := stub.requests
+		rows, next, _, err := client.GetRoles(context.Background(), page)
+		if got := stub.requests - before; got != 1 {
+			t.Fatalf("call %d issued %d requests, want exactly 1", calls, got)
+		}
+		calls++
+		return rows, next, err
+	})
+}
+
+// A non-positive Limit would silently discard every row and end the listing.
+func TestGetRoles_RejectsNonPositiveLimit(t *testing.T) {
+	stub := roleStub(sysIDs(1, 4))
+	client, done := newStubClient(t, stub, nil)
+	defer done()
+
+	for _, limit := range []int{0, -1} {
+		if _, _, _, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: limit}); err == nil {
+			t.Errorf("Limit %d: expected an error", limit)
+		}
+	}
+}
+
+// The empty-page branch returns before the result is built, so it is the one place
+// a lost rate-limit annotation would compile and pass every other test.
+func TestGetRoles_EmptyPageStillCarriesRateLimitAnnotations(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "100")
+		w.Header().Set("X-RateLimit-Remaining", "3")
+		w.Header().Set("X-RateLimit-Reset", "30")
+		w.Header().Set("X-Total-Count", "0")
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(ListResponse[Role]{Result: nil}); err != nil {
+			t.Errorf("failed to encode test response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(uhttp.NewBaseHttpClient(server.Client()), "Basic dGVzdDp0ZXN0", "dev0", nil, nil, nil, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error creating client: %v", err)
+	}
+
+	rows, next, annos, err := client.GetRoles(context.Background(), KeysetPaginationVars{Limit: 50})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 0 || next != "" {
+		t.Fatalf("rows = %d, next = %q; want an empty terminating page", len(rows), next)
+	}
+
+	rl := &v2.RateLimitDescription{}
+	if ok, err := annos.Pick(rl); err != nil || !ok {
+		t.Fatalf("no RateLimitDescription on an empty page (ok=%v, err=%v); the SDK limiter loses pacing data on every listing terminator", ok, err)
+	}
+	if rl.GetRemaining() != 3 {
+		t.Errorf("remaining = %d, want 3", rl.GetRemaining())
+	}
+}
+
+// A post-ACL X-Total-Count makes an emptied window indistinguishable from the end
+// of the table, so the listing ends there. Documents the signal's limit.
+func TestGetRoles_UnderReportsWhenCountIsPostACL(t *testing.T) {
+	stub := roleStub(sysIDs(1, 6), sysID(3), sysID(4))
+	stub.reportPostACLCount = true
+	client, done := newStubClient(t, stub, nil)
+	defer done()
+
+	got := drainRoles(t, client, 2, 20)
+
+	if strings.Join(got, ",") != strings.Join(sysIDs(1, 2), ",") {
+		t.Errorf("rows synced = %v; a post-ACL count ends the listing at the first emptied window", got)
+	}
+}

--- a/pkg/servicenow/request.go
+++ b/pkg/servicenow/request.go
@@ -3,6 +3,7 @@ package servicenow
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -91,13 +92,6 @@ func WithIncludeExternalRefLink() ReqOpt {
 	return WithQueryParam("sysparm_exclude_reference_link", "false")
 }
 
-// WithNoCount skips ServiceNow's X-Total-Count computation (a COUNT(*) over
-// the whole filtered set). Keyset termination doesn't need it -- it only
-// checks for an empty page (see nextKeysetToken).
-func WithNoCount() ReqOpt {
-	return WithQueryParam("sysparm_no_count", "true")
-}
-
 type PaginationVars struct {
 	Limit  int
 	Offset int
@@ -109,8 +103,11 @@ type PaginationVars struct {
 // deep-offset requests degrade on large tables. Service Catalog/ticketing
 // endpoints keep using PaginationVars/WithOffset.
 type KeysetPaginationVars struct {
-	Limit  int
-	LastID string
+	Limit  int    // page size, and the most rows a call may return
+	LastID string // seek cursor
+	// Offset is non-zero only while stepping past an ACL-emptied window, where
+	// the cursor cannot advance on its own.
+	Offset int
 }
 
 // domainFilteredPageSize caps the page size for enumeration calls that add
@@ -130,13 +127,14 @@ func cappedForDomainFilter(userId string, domains []string, vars KeysetPaginatio
 }
 
 // keysetPaginationVarsToReqOptions sets sysparm_limit, appends the sys_id
-// seek condition onto sysparm_query (must run after filterToReqOptions),
-// and disables X-Total-Count via WithNoCount.
+// seek condition onto sysparm_query (must run after filterToReqOptions), and
+// carries the skip offset. X-Total-Count is left on: nextSkipToken needs it to
+// tell an ACL-emptied window from the end of the table.
 func keysetPaginationVarsToReqOptions(vars *KeysetPaginationVars) []ReqOpt {
 	reqOpts := make([]ReqOpt, 0, 3)
 	reqOpts = append(reqOpts, WithPageLimit(vars.Limit))
 	reqOpts = append(reqOpts, WithQueryAppend(keysetCursorFragment(vars.LastID)))
-	reqOpts = append(reqOpts, WithNoCount())
+	reqOpts = append(reqOpts, WithOffset(vars.Offset))
 	return reqOpts
 }
 
@@ -167,6 +165,43 @@ func nextKeysetToken[T any](items []T, idFn func(T) string) string {
 		return ""
 	}
 	return idFn(items[len(items)-1])
+}
+
+// Matches "cursor" or "cursor:offset". The cursor is optional: the first window
+// of a listing can be the emptied one, leaving nothing to seek from.
+var keysetTokenPattern = regexp.MustCompile(`^([0-9a-fA-F]{32})?(?::([0-9]{1,18}))?$`)
+
+// EncodeKeysetToken is the only producer of the page token format. A bare cursor
+// is the common shape: nothing to skip.
+func EncodeKeysetToken(lastID string, offset int) string {
+	if offset == 0 {
+		return lastID
+	}
+	return fmt.Sprintf("%s:%d", lastID, offset)
+}
+
+// ParseKeysetToken is the only consumer of it, returning the cursor and the skip
+// offset.
+func ParseKeysetToken(token string) (string, int, error) {
+	if token == "" {
+		return "", 0, nil
+	}
+
+	match := keysetTokenPattern.FindStringSubmatch(token)
+	if match == nil {
+		return "", 0, fmt.Errorf("malformed page token %q", token)
+	}
+
+	var offset int
+	if match[2] != "" {
+		parsed, err := strconv.Atoi(match[2])
+		if err != nil {
+			return "", 0, fmt.Errorf("malformed offset in page token %q: %w", token, err)
+		}
+		offset = parsed
+	}
+
+	return strings.ToLower(match[1]), offset, nil
 }
 
 type FilterVars struct {

--- a/pkg/servicenow/request_test.go
+++ b/pkg/servicenow/request_test.go
@@ -31,8 +31,8 @@ func TestBuildDomainQuery(t *testing.T) {
 		{
 			name:    "multiple domains are OR'd",
 			field:   "user.email",
-			domains: []string{"draftkings.com", "dk.com"},
-			want:    "user.emailENDSWITH@draftkings.com^ORuser.emailENDSWITH@dk.com",
+			domains: []string{"example.com", "dk.com"},
+			want:    "user.emailENDSWITH@example.com^ORuser.emailENDSWITH@dk.com",
 		},
 		{
 			name:    "single domain",
@@ -55,8 +55,8 @@ func TestBuildDomainQuery(t *testing.T) {
 		{
 			name:    "domains are trimmed and lowercased",
 			field:   "email",
-			domains: []string{" DraftKings.com "},
-			want:    "emailENDSWITH@draftkings.com",
+			domains: []string{" Example.com "},
+			want:    "emailENDSWITH@example.com",
 		},
 	}
 
@@ -92,21 +92,21 @@ func TestPrepareUserToRoleFilter(t *testing.T) {
 			name:    "enumeration (Grants) with allowed domains filters by domain",
 			userId:  "",
 			roleId:  "ROLE1",
-			domains: []string{"draftkings.com"},
-			want:    "role=ROLE1^user.emailENDSWITH@draftkings.com",
+			domains: []string{"example.com"},
+			want:    "role=ROLE1^user.emailENDSWITH@example.com",
 		},
 		{
 			name:    "enumeration with multiple allowed domains ORs the domain conditions, ANDed with role=",
 			userId:  "",
 			roleId:  "ROLE1",
-			domains: []string{"draftkings.com", "dk.com"},
-			want:    "role=ROLE1^user.emailENDSWITH@draftkings.com^ORuser.emailENDSWITH@dk.com",
+			domains: []string{"example.com", "dk.com"},
+			want:    "role=ROLE1^user.emailENDSWITH@example.com^ORuser.emailENDSWITH@dk.com",
 		},
 		{
 			name:    "provisioning check for a specific user does not filter by domain",
 			userId:  "USER1",
 			roleId:  "ROLE1",
-			domains: []string{"draftkings.com"},
+			domains: []string{"example.com"},
 			want:    "user=USER1^role=ROLE1",
 		},
 		{
@@ -140,21 +140,21 @@ func TestPrepareUserToGroupFilter(t *testing.T) {
 			name:    "enumeration (Grants) with allowed domains filters by domain",
 			userId:  "",
 			groupId: "GROUP1",
-			domains: []string{"draftkings.com"},
-			want:    "group=GROUP1^user.emailENDSWITH@draftkings.com",
+			domains: []string{"example.com"},
+			want:    "group=GROUP1^user.emailENDSWITH@example.com",
 		},
 		{
 			name:    "enumeration with multiple allowed domains ORs the domain conditions, ANDed with group=",
 			userId:  "",
 			groupId: "GROUP1",
-			domains: []string{"draftkings.com", "dk.com"},
-			want:    "group=GROUP1^user.emailENDSWITH@draftkings.com^ORuser.emailENDSWITH@dk.com",
+			domains: []string{"example.com", "dk.com"},
+			want:    "group=GROUP1^user.emailENDSWITH@example.com^ORuser.emailENDSWITH@dk.com",
 		},
 		{
 			name:    "provisioning check for a specific user does not filter by domain",
 			userId:  "USER1",
 			groupId: "GROUP1",
-			domains: []string{"draftkings.com"},
+			domains: []string{"example.com"},
 			want:    "user=USER1^group=GROUP1",
 		},
 		{
@@ -209,26 +209,19 @@ func TestKeysetCursorFragment(t *testing.T) {
 // options appended after in the same ReqOpt slice. The seek condition must
 // AND onto the existing filter query rather than clobbering it.
 func TestKeysetPaginationVarsToReqOptions_ComposesWithFilterQuery(t *testing.T) {
-	filterOpts := filterToReqOptions(prepareUserToRoleFilter("", "ROLE1", []string{"draftkings.com"}))
+	filterOpts := filterToReqOptions(prepareUserToRoleFilter("", "ROLE1", []string{"example.com"}))
 	paginationOpts := keysetPaginationVarsToReqOptions(&KeysetPaginationVars{Limit: 50, LastID: "abc123"})
 
 	req := newTestRequest(t)
 	applyReqOpts(req, filterOpts...)
 	applyReqOpts(req, paginationOpts...)
 
-	wantQuery := "role=ROLE1^user.emailENDSWITH@draftkings.com^sys_id>abc123^ORDERBYsys_id"
+	wantQuery := "role=ROLE1^user.emailENDSWITH@example.com^sys_id>abc123^ORDERBYsys_id"
 	if got := req.URL.Query().Get("sysparm_query"); got != wantQuery {
 		t.Errorf("sysparm_query = %q, want %q", got, wantQuery)
 	}
 	if got := req.URL.Query().Get("sysparm_limit"); got != "50" {
 		t.Errorf("sysparm_limit = %q, want %q", got, "50")
-	}
-	// ServiceNow computes X-Total-Count (a COUNT(*) over the whole filtered
-	// set) unless told not to, which is expensive on every page. Termination
-	// keys off an empty page only (see nextKeysetToken), so the count is
-	// suppressed because it's never read.
-	if got := req.URL.Query().Get("sysparm_no_count"); got != "true" {
-		t.Errorf("sysparm_no_count = %q, want %q", got, "true")
 	}
 }
 
@@ -240,25 +233,16 @@ func TestKeysetPaginationVarsToReqOptions_ComposesWithFilterQuery(t *testing.T) 
 // (sys_id greater than the max possible value) returned zero rows, proving
 // the seek constrains every branch rather than only the trailing one.
 func TestKeysetPaginationVarsToReqOptions_ComposesWithMultiDomainFilterQuery(t *testing.T) {
-	filterOpts := filterToReqOptions(prepareUserToRoleFilter("", "ROLE1", []string{"draftkings.com", "dk.com"}))
+	filterOpts := filterToReqOptions(prepareUserToRoleFilter("", "ROLE1", []string{"example.com", "dk.com"}))
 	paginationOpts := keysetPaginationVarsToReqOptions(&KeysetPaginationVars{Limit: 50, LastID: "abc123"})
 
 	req := newTestRequest(t)
 	applyReqOpts(req, filterOpts...)
 	applyReqOpts(req, paginationOpts...)
 
-	wantQuery := "role=ROLE1^user.emailENDSWITH@draftkings.com^ORuser.emailENDSWITH@dk.com^sys_id>abc123^ORDERBYsys_id"
+	wantQuery := "role=ROLE1^user.emailENDSWITH@example.com^ORuser.emailENDSWITH@dk.com^sys_id>abc123^ORDERBYsys_id"
 	if got := req.URL.Query().Get("sysparm_query"); got != wantQuery {
 		t.Errorf("sysparm_query = %q, want %q", got, wantQuery)
-	}
-}
-
-func TestWithNoCount(t *testing.T) {
-	req := newTestRequest(t)
-	applyReqOpts(req, WithNoCount())
-
-	if got := req.URL.Query().Get("sysparm_no_count"); got != "true" {
-		t.Errorf("sysparm_no_count = %q, want %q", got, "true")
 	}
 }
 
@@ -309,21 +293,21 @@ func TestCappedForDomainFilter(t *testing.T) {
 		{
 			name:    "enumeration with allowed domains caps a larger limit",
 			userId:  "",
-			domains: []string{"draftkings.com"},
+			domains: []string{"example.com"},
 			limit:   200,
 			want:    domainFilteredPageSize,
 		},
 		{
 			name:    "enumeration with allowed domains leaves an already-small limit alone",
 			userId:  "",
-			domains: []string{"draftkings.com"},
+			domains: []string{"example.com"},
 			limit:   10,
 			want:    10,
 		},
 		{
 			name:    "provisioning check (specific userId) is never capped",
 			userId:  "USER1",
-			domains: []string{"draftkings.com"},
+			domains: []string{"example.com"},
 			limit:   200,
 			want:    200,
 		},


### PR DESCRIPTION
The keyset change ended the listing on any empty page. ServiceNow cuts the page before applying read ACLs, so an empty page doesn't mean there's nothing left -- the sync stopped there and lost everything after it.

Now an empty page checks X-Total-Count and skips past the hidden rows instead of stopping.